### PR TITLE
WIP: python-compiler 컨테이너 연동 및 실행 테스트 중

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,47 @@
+# 빌드 결과물
+.gradle
+/out
+/bin
+dist/
+*.class
+*.jar
+*.war
+
+# IDE 설정 파일
+.idea/
+*.iml
+*.ipr
+*.iws
+.project
+.classpath
+.factorypath
+.settings/
+.sts4-cache
+.vscode/
+
+# 테스트용/임시 파일
+main.c
+main.java
+main.py
+main.out
+input.txt
+output.txt
+compile_error.txt
+runtime_error.txt
+
+# 기타
+*.log
+*.tmp
+*.swp
+.DS_Store
+
+# Git
+.git
+.gitignore
+
+# OS/에디터 캐시
+Thumbs.db
+ehthumbs.db
+*.bak
+*.old
+*.orig

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,14 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# 테스트용 소스 및 결과 파일 (컴파일러 테스트용)
+main.c
+main.java
+main.py
+main.out
+input.txt
+output.txt
+compile_error.txt
+runtime_error.txt
+entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
-# OpenJDK 17 기반의 경량 이미지 사용
-FROM openjdk:17-jdk-slim
+FROM openjdk:17-slim
 
-# 작업 디렉토리 생성
+# docker 명령어 설치
+RUN apt-get update && apt-get install -y docker.io
+
 WORKDIR /app
-
-# Gradle 빌드된 JAR 파일 복사
 COPY build/libs/Debug_Visual-0.0.1-SNAPSHOT.jar app.jar
 
-# 애플리케이션 실행
-CMD ["java", "-jar", "app.jar"]
-
-# 애플리케이션이 실행될 포트 지정
 EXPOSE 8080
+CMD ["java", "-jar", "app.jar"]

--- a/c/Dockerfile
+++ b/c/Dockerfile
@@ -1,0 +1,2 @@
+FROM gcc:latest
+WORKDIR /usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3.8'
 
 services:
   backend:
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     build: .
     ports:
       - "8080:8080"
@@ -13,7 +15,7 @@ services:
       SPRING_DATASOURCE_PASSWORD: hmjeoung33
 
   db:
-    image: mysql:9.0
+    image: mysql:8.0
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: hmjeoung33
@@ -21,4 +23,26 @@ services:
     ports:
       - "3306:3306"
 
+  python-compiler:
+    build:
+      context: ./python
+    image: python-compiler
+    container_name: python-compiler
+    stdin_open: true
+    tty: true
 
+  java-compiler:
+    build:
+      context: ./java
+    image: java-compiler
+    container_name: java-compiler
+    stdin_open: true
+    tty: true
+
+  c-compiler:
+    build:
+      context: ./c
+    image: c-compiler
+    container_name: c-compiler
+    stdin_open: true
+    tty: true

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,0 +1,2 @@
+FROM openjdk:17
+WORKDIR /usr/src/app

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.9
+WORKDIR /usr/src/app
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh

--- a/src/main/java/com/dmu/debug_visual/controller/CompilerController.java
+++ b/src/main/java/com/dmu/debug_visual/controller/CompilerController.java
@@ -1,0 +1,33 @@
+package com.dmu.debug_visual.controller;
+
+import com.dmu.debug_visual.dto.CodeRequest;
+import com.dmu.debug_visual.service.CompilerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+// controller/CompilerController.java
+@RestController
+@RequestMapping("/api/compile")
+@RequiredArgsConstructor
+@Tag(name = "컴파일러 API", description = "언어별 코드 실행 API")
+public class CompilerController {
+
+    private final CompilerService compilerService;
+
+    @Operation(summary = "코드 실행", description = "언어와 코드를 입력받아 실행 결과를 반환합니다.")
+    @PostMapping("/{language}")
+    public ResponseEntity<String> compile(
+            @PathVariable String language,
+            @RequestBody CodeRequest request) {
+
+        try {
+            String result = compilerService.execute(language, request.getCode(), request.getInput());
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body("실행 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/dmu/debug_visual/dto/CodeRequest.java
+++ b/src/main/java/com/dmu/debug_visual/dto/CodeRequest.java
@@ -1,0 +1,10 @@
+package com.dmu.debug_visual.dto;
+
+import lombok.Data;
+
+@Data
+public class CodeRequest {
+    private String language; // "python", "java", "c" → 선택적
+    private String code;     // 실행할 코드
+    private String input;    // 표준 입력
+}

--- a/src/main/java/com/dmu/debug_visual/service/CompilerService.java
+++ b/src/main/java/com/dmu/debug_visual/service/CompilerService.java
@@ -1,0 +1,57 @@
+package com.dmu.debug_visual.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Service
+@RequiredArgsConstructor
+public class CompilerService {
+
+    public String execute(String language, String code, String input) throws IOException, InterruptedException {
+        Path tempDir = Files.createTempDirectory("code_");
+        String filename = switch (language.toLowerCase()) {
+            case "python" -> "main.py";
+            case "java" -> "Main.java";
+            case "c"     -> "main.c";
+            default -> throw new IllegalArgumentException("지원하지 않는 언어입니다.");
+        };
+
+        // 1. 파일 저장
+        Files.writeString(tempDir.resolve(filename), code);
+        Files.writeString(tempDir.resolve("input.txt"), input);
+
+        // 2. Docker 실행
+        String container = switch (language.toLowerCase()) {
+            case "python" -> "python-compiler";
+            case "java"   -> "java-compiler";
+            case "c"      -> "c-compiler";
+            default -> throw new IllegalArgumentException("지원하지 않는 언어입니다.");
+        };
+
+        ProcessBuilder pb = new ProcessBuilder(
+                "docker", "run", "--rm",
+                "-v", tempDir.toAbsolutePath() + ":/usr/src/app",
+                container,
+                "bash", "entrypoint.sh"
+        );
+
+        pb.redirectErrorStream(true);
+        Process process = pb.start();
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+        StringBuilder output = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) {
+            output.append(line).append("\n");
+        }
+
+        process.waitFor();
+        return output.toString();
+    }
+}


### PR DESCRIPTION
## 🧩 개요
* Spring Boot에서 언어별 컴파일러(Docker 컨테이너)를 실행하는 구조를 구축 중입니다.
* 현재 Python 코드 실행을 위한 `python-compiler` 이미지와 컨테이너 연동을 테스트하고 있습니다.

## ✅ 주요 변경사항
* `docker-compose.yml`에 `python-compiler`, `java-compiler`, `c-compiler` 서비스 추가

* `python/Dockerfile` 작성 및 `entrypoint.sh` 복사 실행 시도

* `.dockerignore` 파일 정리 (필요 파일 누락 방지)

* `CompilerService.java` 내에서 `Docker` 컨테이너 실행 로직 작성

## ⚠️ 현재 진행 상황 및 이슈
* `entrypoint.sh`가 컨테이너 내에서 누락되는 문제 발생 → `.dockerignore` 및 `context` 확인 중

* Spring 코드에서 `docker run` 실행 시, 이미지 이름 불일치로 실행 실패 → 현재는 수정된 상태

* `Dockerfile` 수정 후에도 빌드 `context`에 따라 파일이 복사되지 않는 현상 지속 확인 중

## 🧪 테스트
* `docker-compose build --no-cache` 및 `docker exec` 등을 통해 직접 컨테이너 내부 확인

* `Spring Devtools` 통해 Docker 컨테이너 동작 여부 확인

## 📌 향후 계획
* `entrypoint.sh` 복사 실패 원인 명확화 (`build context` 및 `ignore` 파일 재검토)

* 다른 언어(JAVA, C) 컨테이너에 동일 방식 적용

* Swagger를 통한 API 테스트 인터페이스 구성 예정

## 📎 관련 이슈
* #11 

