### PR TITLE
feat: Spring에서 Python Docker 컨테이너 연동 기능 구현

### DIFF
--- a/src/main/java/com/dmu/debug_visual/config/SecurityConfig.java
+++ b/src/main/java/com/dmu/debug_visual/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.client.RestTemplate;
 
 
 @Configuration
@@ -16,5 +17,10 @@ public class SecurityConfig {
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
 
 }

--- a/src/main/java/com/dmu/debug_visual/controller/CodeController.java
+++ b/src/main/java/com/dmu/debug_visual/controller/CodeController.java
@@ -1,0 +1,40 @@
+package com.dmu.debug_visual.controller;
+
+import com.dmu.debug_visual.dto.CodeRunRequestDTO;
+import com.dmu.debug_visual.service.CodeExecutionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/code")
+@Tag(name = "코드 실행 API", description = "Python, Java, C 언어 코드 실행 기능 제공")
+public class CodeController {
+
+    private final CodeExecutionService codeExecutionService;
+
+    @Operation(
+            summary = "코드 실행",
+            description = "입력받은 코드와 입력값을 언어에 따라 실행하고 결과를 반환합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 실행됨"),
+            @ApiResponse(responseCode = "400", description = "컴파일 또는 실행 에러", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @PostMapping("/run")
+    public ResponseEntity<String> runCode(@RequestBody CodeRunRequestDTO requestDTO) {
+        String result = codeExecutionService.runCode(
+                requestDTO.getCode(),
+                requestDTO.getInput(),
+                requestDTO.getLang()
+        );
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/dmu/debug_visual/dto/CodeRunRequestDTO.java
+++ b/src/main/java/com/dmu/debug_visual/dto/CodeRunRequestDTO.java
@@ -1,0 +1,17 @@
+package com.dmu.debug_visual.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+public class CodeRunRequestDTO {
+
+    @Schema(description = "사용자가 작성한 소스코드", example = "print('Hello')")
+    private String code;
+
+    @Schema(description = "표준 입력값", example = "5")
+    private String input;
+
+    @Schema(description = "언어 종류 (python, java, c)", example = "python")
+    private String lang;
+}

--- a/src/main/java/com/dmu/debug_visual/dto/CodeRunResponseDTO.java
+++ b/src/main/java/com/dmu/debug_visual/dto/CodeRunResponseDTO.java
@@ -1,0 +1,8 @@
+package com.dmu.debug_visual.dto;
+
+import lombok.Data;
+
+@Data
+public class CodeRunResponseDTO {
+    private String result; // Python 서버의 stdout
+}

--- a/src/main/java/com/dmu/debug_visual/service/CodeExecutionService.java
+++ b/src/main/java/com/dmu/debug_visual/service/CodeExecutionService.java
@@ -1,0 +1,34 @@
+package com.dmu.debug_visual.service;
+
+import com.dmu.debug_visual.dto.CodeRunRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class CodeExecutionService {
+
+    private final RestTemplate restTemplate;
+
+    public String runCode(String code, String input, String lang) {
+        CodeRunRequestDTO request = new CodeRunRequestDTO();
+        request.setCode(code);
+        request.setInput(input);
+        request.setLang(lang);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<CodeRunRequestDTO> entity = new HttpEntity<>(request, headers);
+
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "http://localhost:5050/run", entity, String.class
+        );
+
+        return response.getBody();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,16 +6,16 @@ spring.profiles.active=dev
 
 
 # MySQL - RDS
-spring.datasource.url=jdbc:mysql://debugvisual-rds.cl2o2mce4l8e.ap-northeast-2.rds.amazonaws.com:3306/DebugVisual_RDS?useSSL=false&serverTimezone=Asia/Seoul
-spring.datasource.username=admin
-spring.datasource.password=debugvi33!
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+#spring.datasource.url=jdbc:mysql://debugvisual-rds.cl2o2mce4l8e.ap-northeast-2.rds.amazonaws.com:3306/DebugVisual_RDS?useSSL=false&serverTimezone=Asia/Seoul
+#spring.datasource.username=admin
+#spring.datasource.password=debugvi33!
+#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # MySQL - Local
-#spring.datasource.url=jdbc:mysql://localhost:3306/debugdb?serverTimezone=Asia/Seoul
-#spring.datasource.username=root
-#spring.datasource.password=hmjeoung33
-#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/debugdb?serverTimezone=Asia/Seoul
+spring.datasource.username=root
+spring.datasource.password=hmjeoung33
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # MYSQL - Docker
 #spring.datasource.url=${SPRING_DATASOURCE_URL}


### PR DESCRIPTION
Python으로 작성된 코드 실행을 위해 Flask 서버와 통신하여 실행 결과를 받아오는 기능을 추가했습니다.

### 주요 변경 사항
- `/api/code/run` POST API에서 Python 코드 실행 요청 시 localhost:5050/run 으로 요청 전달
- 언어에 따라 Docker 이미지를 선택하도록 CodeExecutionService 수정
- Swagger에서 테스트 가능하도록 DTO 및 문서화 정리

### 테스트
- Swagger에서 코드, 입력값, 언어(Python) 설정 후 정상 응답 확인
- 반환값 출력 및 오류 코드 500 대응 처리

### 기타
- 추후 파일 저장 방식(S3 or Local Download)에 따라 반환 로직 확장 필요
