### PR TITLE
[Feat] visualize API 추가 및 Flask 연동 구현

### DIFF
--- a/src/main/java/com/dmu/debug_visual/controller/CodeController.java
+++ b/src/main/java/com/dmu/debug_visual/controller/CodeController.java
@@ -62,4 +62,42 @@ public class CodeController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/visualize")
+    @Operation(
+            summary = "코드 시각화 (GPT 설명 포함)",
+            description = "코드를 실행하고 실행 결과 및 GPT 기반 AST 설명을 반환합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공적으로 실행됨",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CodeRunResponseDTO.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "stdout": "Hello",
+                                      "stderr": "",
+                                      "exitCode": 0,
+                                      "success": true,
+                                      "ast": "1+2=3"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "컴파일 또는 실행 에러", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    public ResponseEntity<CodeRunResponseDTO> visualizeCode(@RequestBody CodeRunRequestDTO requestDTO) {
+        CodeRunResponseDTO response = codeExecutionService.visualizeCode(
+                requestDTO.getCode(),
+                requestDTO.getInput(),
+                requestDTO.getLang()
+        );
+        return ResponseEntity.ok(response);
+    }
+
+
 }

--- a/src/main/java/com/dmu/debug_visual/dto/CodeRunResponseDTO.java
+++ b/src/main/java/com/dmu/debug_visual/dto/CodeRunResponseDTO.java
@@ -11,6 +11,7 @@ import lombok.*;
 @Builder
 @Schema(description = "코드 실행 결과 응답")
 public class CodeRunResponseDTO {
+
     @Schema(description = "표준 출력 결과", example = "Hello")
     private String stdout;
 
@@ -22,4 +23,7 @@ public class CodeRunResponseDTO {
 
     @Schema(description = "성공 여부", example = "true")
     private boolean success;
+
+    @Schema(description = "코드 AST 또는 GPT 설명 (visualize 요청 시)", example = "1+2=3")
+    private String ast;
 }

--- a/src/main/java/com/dmu/debug_visual/service/CodeExecutionService.java
+++ b/src/main/java/com/dmu/debug_visual/service/CodeExecutionService.java
@@ -53,4 +53,29 @@ public class CodeExecutionService {
         }
     }
 
+    public CodeRunResponseDTO visualizeCode(String code, String input, String lang) {
+        CodeRunRequestDTO request = new CodeRunRequestDTO(code, input, lang);
+
+        try {
+            return webClient.post()
+                    .uri(compilerPythonUrl.replace("/run", "/visualize"))  // ⭐ 핵심: /visualize 엔드포인트 사용
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(CodeRunResponseDTO.class)
+                    .block();
+        } catch (Exception e) {
+            System.out.println("🚨 WebClient 예외 발생 (visualize): " + e.getMessage());
+            return CodeRunResponseDTO.builder()
+                    .stdout("")
+                    .stderr("WebClient 예외 (visualize): " + e.getMessage())
+                    .exitCode(1)
+                    .success(false)
+                    .ast("")  // visualize는 ast 빈 문자열로라도 반환
+                    .build();
+        }
+    }
+
+
 }


### PR DESCRIPTION
## 개요

프론트엔드 "코드 시각화" 버튼 클릭 시 호출되는 `/visualize` API 를 Spring 서버에 추가하였습니다.
해당 API는 Flask 서버의 `/visualize` 엔드포인트와 연동하여 다음 데이터를 반환합니다:

- 코드 실행 결과 (`stdout`, `stderr`, `exitCode`, `success`)
- GPT 기반 코드 설명 결과 (`ast`)

## 주요 변경 사항

- `/visualize` API 엔드포인트 추가
- Flask 서버 `/visualize` 호출 로직 추가
- 기존 `/run` API 구조 참고하여 구현
- 응답 구조: 실행 결과 + GPT 응답(JSON 형태)

## 응답 구조 예시

```json
{
  "stdout": "...",  // 실행 결과 출력
  "stderr": "...",  // 실행 오류 출력
  "exitCode": 0,
  "success": true,
  "ast": "GPT가 생성한 코드 설명 텍스트"
}
```

## 관련 이슈
#16 