### PR TITLE
feat: 특정 API에만 JWT 인증이 적용되도록 SecurityConfig 수정 (#20)

### DIFF
--- a/src/main/java/com/dmu/debug_visual/config/SecurityConfig.java
+++ b/src/main/java/com/dmu/debug_visual/config/SecurityConfig.java
@@ -5,10 +5,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -32,28 +35,79 @@ public class SecurityConfig {
     @Value("${compiler.python.url}")
     private String compilerPythonUrl;
 
+    // 1. JWT 인증이 필요한 API를 위한 필터 체인 (우선순위 1)
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    @Order(1)
+    @Profile("!dev")
+    public SecurityFilterChain jwtFilterChain(HttpSecurity http) throws Exception {
         http
+                .securityMatcher("/api/posts/**", "/api/notifications/**", "/api/admin/**", "/api/report/**", "/api/comments/**") // 이 경로들에 대해서만 이 필터 체인을 적용
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(csrf -> csrf.disable())
+                .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/api/users/login",
-                                "/api/users/signup",
-                                "/swagger-ui/**",
-                                "/v3/api-docs/**"
-                        ).permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/posts/**").hasAnyRole("USER", "ADMIN")
                         .requestMatchers("/api/notifications/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers("/api/report/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers("/api/comments/**").hasAnyRole("USER", "ADMIN")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, userRepository),
                         UsernamePasswordAuthenticationFilter.class)
-                .formLogin(form -> form.disable())
-                .httpBasic(basic -> basic.disable());
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable);
 
+        return http.build();
+    }
+
+    // 2. JWT 인증이 필요 없는 API 및 기타 경로를 위한 필터 체인 (우선순위 2)
+    @Bean
+    @Order(2)
+    @Profile("!dev")
+    public SecurityFilterChain publicFilterChain(HttpSecurity http) throws Exception {
+        http
+                // securityMatcher를 지정하지 않으면 나머지 모든 요청을 처리합니다.
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        // 로그인, 회원가입, Swagger 등 인증이 필요 없는 경로는 여기서 permitAll() 처리
+                        .requestMatchers(
+                                "/api/users/login",
+                                "/api/users/signup",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/api/code/**"
+                        ).permitAll()
+                        .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
+
+    // "dev" 프로파일에서 사용할 보안 설정
+    @Bean
+    @Profile("dev")
+    public SecurityFilterChain devSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        // dev 환경에서 인증 없이 접근을 허용할 경로
+                        .requestMatchers(
+                                "/api/admin/**",
+                                "/api/users/login",
+                                "/api/users/signup",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/api/code/**"
+                        ).permitAll()
+                        // 그 외 모든 요청은 인증을 요구하도록 설정 (!dev 환경과 유사하게)
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, userRepository),
+                        UsernamePasswordAuthenticationFilter.class)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable);
         return http.build();
     }
 
@@ -74,8 +128,6 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOriginPatterns(List.of("*"));
-        // 또는 특정 도메인만 허용할 경우:
-//        config.setAllowedOrigins(List.of("https://zivorp.com", "http://zivorp.com"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);


### PR DESCRIPTION
## 📝 설명 (Description)

> 이 PR은 어떤 문제를 해결하고, 어떤 작업을 수행했나요?

기존의 모든 API에 JWT 인증이 적용되던 문제를 해결하기 위해, 인증이 필요한 API와 그렇지 않은 API를 분리하도록 `SecurityConfig` 설정을 수정했습니다.

---

## ✨ 변경 사항 (Changes)

> 이 PR에서 어떤 부분이 변경되었나요? 구체적인 목록으로 작성하면 좋습니다.

- `@Order`와 `securityMatcher`를 사용하여 `SecurityFilterChain`을 인증용/공개용으로 분리했습니다.
- 인증이 필요한 경로는 `/api/posts/**`, `/api/notifications/**`, `/api/admin/**`으로 지정하고 `jwtFilterChain`에서 처리하도록 했습니다.
- 로그인, 회원가입 등 인증이 필요 없는 경로는 `publicFilterChain`에서 `permitAll()`로 처리합니다.

---

## 🔗 이슈 연결 (Linked Issues)

> 이 PR이 어떤 이슈와 관련이 있나요?

Closes: #20