### PR TITLE
feat: 대댓글 중첩 기능 제한 (#22)

### DIFF
--- a/src/main/java/com/dmu/debug_visual/community/entity/Comment.java
+++ b/src/main/java/com/dmu/debug_visual/community/entity/Comment.java
@@ -26,6 +26,7 @@ public class Comment {
     @ManyToOne
     private Comment parent; // 대댓글일 경우 상위 댓글
 
+    @Builder.Default
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
     private List<Comment> children = new ArrayList<>();
 

--- a/src/main/java/com/dmu/debug_visual/community/entity/Post.java
+++ b/src/main/java/com/dmu/debug_visual/community/entity/Post.java
@@ -27,9 +27,6 @@ public class Post {
     @Column(name = "tag")
     private List<PostTag> tags;
 
-
-//    private String imageUrl;
-
     @ManyToOne
     private User writer;
 

--- a/src/main/java/com/dmu/debug_visual/community/service/CommentService.java
+++ b/src/main/java/com/dmu/debug_visual/community/service/CommentService.java
@@ -34,6 +34,12 @@ public class CommentService {
         if (dto.getParentId() != null && dto.getParentId() != 0) {
             parent = commentRepository.findById(dto.getParentId())
                     .orElseThrow(() -> new RuntimeException("상위 댓글 없음"));
+
+            // 대댓글의 부모가 null이 아니면(즉, 대댓글에 대댓글을 다는 경우) 에러 발생
+            if (parent.getParent() != null) {
+                throw new IllegalArgumentException("대댓글에는 답글을 달 수 없습니다.");
+            }
+
             builder.parent(parent);
 
             if (!user.getUserNum().equals(parent.getWriter().getUserNum())) {

--- a/src/main/java/com/dmu/debug_visual/community/service/PostService.java
+++ b/src/main/java/com/dmu/debug_visual/community/service/PostService.java
@@ -27,7 +27,6 @@ public class PostService {
                 .title(dto.getTitle())
                 .content(dto.getContent())
                 .tags(dto.getTags())
-//                .imageUrl(dto.getImageUrl())
                 .writer(user)
                 .build();
 
@@ -62,7 +61,6 @@ public class PostService {
                 .content(post.getContent())
                 .writer(post.getWriter().getName()) // 수정
                 .tags(post.getTags())
-//                .imageUrl(post.getImageUrl())
                 .createdAt(post.getCreatedAt())
                 .likeCount(likeRepository.countByPost(post))
                 .build();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,16 +6,16 @@ spring.profiles.active=dev
 
 
 # MySQL - RDS
-#spring.datasource.url=jdbc:mysql://debugvisual-rds-mysql.cl2o2mce4l8e.ap-northeast-2.rds.amazonaws.com:3306/DebugVisual_RDS?useSSL=false&serverTimezone=Asia/Seoul
-#spring.datasource.username=admin
-#spring.datasource.password=debugvi33!
-#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://zivorp-rds-mysql.cl2o2mce4l8e.ap-northeast-2.rds.amazonaws.com:3306/Zivorp_RDS_MySQL?useSSL=false&serverTimezone=Asia/Seoul
+spring.datasource.username=admin
+spring.datasource.password=zivorp33!
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # MySQL - Local
-spring.datasource.url=jdbc:mysql://localhost:3306/debugdb?serverTimezone=Asia/Seoul
-spring.datasource.username=root
-spring.datasource.password=hmjeoung33
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+#spring.datasource.url=jdbc:mysql://localhost:3306/debugdb?serverTimezone=Asia/Seoul
+#spring.datasource.username=root
+#spring.datasource.password=hmjeoung33
+#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # MYSQL - Docker
 #spring.datasource.url=${SPRING_DATASOURCE_URL}


### PR DESCRIPTION
## 📝 설명 (Description)

기존 댓글 기능은 무한으로 대댓글 생성이 가능하여 UI 가독성 저하 및 데이터 구조 복잡성 문제가 있었습니다. 
이 PR은 댓글의 깊이를 1단계('원 댓글' -> '대댓글')로 제한하여 이 문제를 해결합니다.

---

## ✨ 변경 사항 (Changes)

- `CommentService`의 댓글 생성 메서드에 부모 댓글의 깊이를 검증하는 로직을 추가했습니다.
- 부모 댓글이 존재하는 경우(대댓글 작성 시), 해당 부모가 원 댓글(`parent == null`)이 아니면 `IllegalArgumentException`을 발생시켜 중첩 생성을 막습니다.
- 관련 테스트 코드를 추가하여 로직의 정확성을 검증했습니다.
- 불필요한 주석 제거도 같이 작업하였습니다.

---

## 🔗 이슈 연결 (Linked Issues)

Closes: #22