### PR TITLE
fix: post & comment GET 허용(게시글 및 댓글 조회 API 인증 예외 처리)

### DIFF
--- a/src/main/java/com/dmu/debug_visual/config/SecurityConfig.java
+++ b/src/main/java/com/dmu/debug_visual/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET, "/api/posts/**", "/api/comments/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/posts/**").hasAnyRole("USER", "ADMIN")
                         .requestMatchers("/api/notifications/**").hasAnyRole("USER", "ADMIN")
@@ -81,6 +82,7 @@ public class SecurityConfig {
                                 "/api/comments",
                                 "/api/posts"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/posts/**", "/api/comments/**").permitAll()
                         .anyRequest().permitAll()
                 );
 


### PR DESCRIPTION
## 📋 PR 개요
비로그인 사용자도 커뮤니티의 게시글과 댓글을 조회할 수 있도록 `SecurityConfig`를 수정하여 조회(GET) API에 대한 인증 요구를 제거합니다.

---

## 💻 주요 변경 사항
- **`SecurityConfig.java` 수정**:
  - `jwtFilterChain`과 `devSecurityFilterChain`에 `HttpMethod.GET`을 사용하는 아래 경로들에 대해 `.permitAll()` 규칙을 추가했습니다.
    - `GET /api/posts/**`
    - `GET /api/comments/**`
- 이를 통해 게시글/댓글 생성(POST) 및 삭제(DELETE) 등 다른 API는 기존의 인증 로직을 유지하면서, 조회 기능만 선택적으로 공개하도록 변경했습니다.

---

## 🔗 관련 이슈
Closes #24 
