### PR TITLE
feat: 파일 생성 및 수정(덮어쓰기) 기능 추가(#32)

### DIFF
--- a/src/main/java/com/dmu/debug_visual/file_upload/CodeFileRepository.java
+++ b/src/main/java/com/dmu/debug_visual/file_upload/CodeFileRepository.java
@@ -1,0 +1,14 @@
+package com.dmu.debug_visual.file_upload;
+
+
+import com.dmu.debug_visual.file_upload.entity.CodeFile;
+import com.dmu.debug_visual.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CodeFileRepository extends JpaRepository<CodeFile, Long> {
+    Optional<CodeFile> findByFileUUID(String fileUUID);
+    List<CodeFile> findByUser(User user); // '/api/files/my' 기능을 위해
+}

--- a/src/main/java/com/dmu/debug_visual/file_upload/FileController.java
+++ b/src/main/java/com/dmu/debug_visual/file_upload/FileController.java
@@ -1,16 +1,17 @@
 package com.dmu.debug_visual.file_upload;
 
-import com.dmu.debug_visual.file_upload.service.S3Uploader;
+import com.dmu.debug_visual.file_upload.dto.FileResponseDTO;
+import com.dmu.debug_visual.file_upload.dto.UserFileDTO;
+import com.dmu.debug_visual.file_upload.service.FileService;
 import com.dmu.debug_visual.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,55 +21,55 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.List;
 
-@Tag(name = "파일 관리 API", description = "S3 파일 업로드 및 사용자별 파일 목록 조회를 제공하는 컨트롤러")
+@Tag(name = "파일 관리 API", description = "S3 파일 생성, 수정(덮어쓰기) 및 사용자별 파일 목록 조회를 제공합니다.")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/files")
+@RequestMapping("/api/file") // 경로를 단수로 통일
 public class FileController {
 
-    private final S3Uploader s3Uploader;
+    private final FileService fileService;
 
-    @Operation(summary = "파일 업로드", description = "form-data 형식으로 단일 파일을 AWS S3에 업로드하고, 저장된 파일의 URL을 반환합니다. JWT 인증이 필요합니다.")
+    @Operation(summary = "파일 저장 또는 수정 (덮어쓰기)",
+            description = "form-data로 파일을 업로드합니다. `fileUUID` 파라미터 유무에 따라 동작이 달라집니다.\n\n" +
+                    "- **`fileUUID`가 없으면**: 신규 파일로 저장하고 새로운 `fileUUID`를 발급합니다.\n" +
+                    "- **`fileUUID`가 있으면**: 해당 `fileUUID`를 가진 기존 파일을 덮어씁니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "업로드 성공",
-                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string", example = "https://your-bucket.s3.amazonaws.com/.../file.txt"))),
-            @ApiResponse(responseCode = "401", description = "인증 실패 (JWT 토큰 누락 또는 유효하지 않음)",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류 (파일 업로드 실패)",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "요청 성공 (생성 또는 수정 완료)",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = FileResponseDTO.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (JWT 토큰 누락 또는 유효하지 않음)", content = @Content),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (타인의 파일 수정을 시도)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 `fileUUID`로 수정 요청", content = @Content)
     })
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<String> uploadFile(
+    public ResponseEntity<FileResponseDTO> uploadOrUpdateFile(
+            @Parameter(description = "업로드할 파일")
             @RequestParam("file") MultipartFile file,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        String userId = userDetails.getUsername();
+            @Parameter(description = "수정할 파일의 고유 ID. 신규 업로드 시에는 생략합니다.")
+            @RequestParam(value = "fileUUID", required = false) String fileUUID,
 
-        try {
-            String fileUrl = s3Uploader.upload(file, userId + "-codes");
-            return ResponseEntity.ok(fileUrl);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("파일 업로드에 실패했습니다.");
-        }
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws IOException {
+
+        // CustomUserDetails에서 사용자 ID (Long 타입)를 가져오는 메소드가 있다고 가정합니다.
+        // 예: userDetails.getId()
+        String currentUserId = userDetails.getUsername();
+
+        FileResponseDTO fileResponse = fileService.saveOrUpdateFile(fileUUID, file, currentUserId);
+        return ResponseEntity.ok(fileResponse);
     }
 
-    @Operation(summary = "사용자 파일 목록 조회", description = "특정 사용자가 업로드한 모든 파일의 목록을 조회합니다. 본인의 파일 목록만 조회할 수 있습니다.")
+    @Operation(summary = "내 파일 목록 조회", description = "현재 로그인한 사용자가 생성한 모든 파일의 목록을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공",
-                    content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = S3FileDTO.class)))),
-            @ApiResponse(responseCode = "401", description = "인증 실패 (JWT 토큰 누락 또는 유효하지 않음)",
-                    content = @Content),
-            @ApiResponse(responseCode = "403", description = "접근 권한 없음 (다른 사용자의 파일 목록에 접근 시도)",
-                    content = @Content)
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserFileDTO.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (JWT 토큰 누락 또는 유효하지 않음)", content = @Content)
     })
     @GetMapping("/my")
-    public ResponseEntity<List<S3FileDTO>> listFilesForUser(
+    public ResponseEntity<List<UserFileDTO>> getMyFiles(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        String userId = userDetails.getUsername();
-
-        List<S3FileDTO> files = s3Uploader.listFiles(userId);
-        return ResponseEntity.ok(files);
+        String currentUserId = userDetails.getUsername();
+        List<UserFileDTO> myFiles = fileService.getUserFiles(currentUserId);
+        return ResponseEntity.ok(myFiles);
     }
 }

--- a/src/main/java/com/dmu/debug_visual/file_upload/dto/FileResponseDTO.java
+++ b/src/main/java/com/dmu/debug_visual/file_upload/dto/FileResponseDTO.java
@@ -1,0 +1,11 @@
+package com.dmu.debug_visual.file_upload.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FileResponseDTO {
+    private String fileUUID;
+    private String fileUrl;
+}

--- a/src/main/java/com/dmu/debug_visual/file_upload/dto/S3FileDTO.java
+++ b/src/main/java/com/dmu/debug_visual/file_upload/dto/S3FileDTO.java
@@ -1,4 +1,4 @@
-package com.dmu.debug_visual.file_upload;
+package com.dmu.debug_visual.file_upload.dto;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/dmu/debug_visual/file_upload/dto/UserFileDTO.java
+++ b/src/main/java/com/dmu/debug_visual/file_upload/dto/UserFileDTO.java
@@ -1,0 +1,16 @@
+package com.dmu.debug_visual.file_upload.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+//import java.time.LocalDateTime; // 필요 시 추가
+
+@Getter
+@Builder
+public class UserFileDTO {
+    private String fileUUID;
+    private String originalFileName;
+    // 필요에 따라 파일 URL, 생성일자 등 추가 가능
+    // private String fileUrl;
+    // private LocalDateTime createdAt;
+}

--- a/src/main/java/com/dmu/debug_visual/file_upload/entity/CodeFile.java
+++ b/src/main/java/com/dmu/debug_visual/file_upload/entity/CodeFile.java
@@ -1,0 +1,40 @@
+package com.dmu.debug_visual.file_upload.entity;
+
+import com.dmu.debug_visual.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CodeFile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String fileUUID; // 프론트와 통신할 때 사용할 고유 ID
+
+    @Column(nullable = false)
+    private String originalFileName;
+
+    @Column(nullable = false)
+    private String s3FilePath; // S3에 저장된 실제 경로
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    public CodeFile(String originalFileName, String s3FilePath, User user) {
+        this.fileUUID = UUID.randomUUID().toString();
+        this.originalFileName = originalFileName;
+        this.s3FilePath = s3FilePath;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/dmu/debug_visual/file_upload/service/FileService.java
+++ b/src/main/java/com/dmu/debug_visual/file_upload/service/FileService.java
@@ -1,0 +1,92 @@
+package com.dmu.debug_visual.file_upload.service;
+
+import com.dmu.debug_visual.file_upload.CodeFileRepository;
+import com.dmu.debug_visual.file_upload.dto.FileResponseDTO;
+import com.dmu.debug_visual.file_upload.dto.UserFileDTO;
+import com.dmu.debug_visual.file_upload.entity.CodeFile;
+import com.dmu.debug_visual.user.User;
+import com.dmu.debug_visual.user.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+    private final S3Uploader s3Uploader; // 역할이 단순화된 S3Uploader 주입
+    private final CodeFileRepository codeFileRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public FileResponseDTO saveOrUpdateFile(String fileUUID, MultipartFile file, String userId) throws IOException {
+
+        // 1. 요청 보낸 사용자의 엔티티를 조회합니다.
+        User currentUser = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + userId));
+
+        // 2. fileUUID의 존재 여부로 '최초 저장'과 '수정'을 구분합니다.
+        if (fileUUID == null || fileUUID.isBlank()) {
+
+            // 💡 최초 저장 로직
+            String originalFileName = file.getOriginalFilename();
+            // S3에 저장될 고유한 경로 생성 (사용자별로 폴더를 분리하면 관리하기 좋습니다)
+            String s3FilePath = "user-codes/" + currentUser.getUserId() + "/" + UUID.randomUUID().toString() + "_" + originalFileName;
+
+            // S3Uploader를 통해 파일을 S3에 업로드합니다.
+            String fileUrl = s3Uploader.upload(file, s3FilePath);
+
+            // 파일 메타데이터를 DB(CodeFile 테이블)에 저장합니다.
+            CodeFile newCodeFile = CodeFile.builder()
+                    .originalFileName(originalFileName)
+                    .s3FilePath(s3FilePath)
+                    .user(currentUser)
+                    .build();
+            codeFileRepository.save(newCodeFile);
+
+            // 프론트엔드에 새로 생성된 fileUUID와 파일 URL을 반환합니다.
+            return new FileResponseDTO(newCodeFile.getFileUUID(), fileUrl);
+
+        } else {
+
+            // 💡 수정(덮어쓰기) 로직
+            CodeFile existingCodeFile = codeFileRepository.findByFileUUID(fileUUID)
+                    .orElseThrow(() -> new EntityNotFoundException("File not found with UUID: " + fileUUID));
+
+            // (보안) 파일을 수정하려는 사용자가 실제 소유자인지 확인합니다.
+            if (!existingCodeFile.getUser().getUserId().equals(currentUser.getUserId())) {
+                throw new IllegalStateException("You do not have permission to modify this file.");
+            }
+
+            // S3Uploader에 "기존과 동일한 경로"를 전달하여 파일을 덮어쓰게 합니다.
+            String fileUrl = s3Uploader.upload(file, existingCodeFile.getS3FilePath());
+
+            // DB 정보는 그대로 유지합니다. (수정 시간이 필요하다면 엔티티에 필드 추가 후 갱신)
+
+            // 프론트엔드에 기존 fileUUID와 갱신된 파일 URL을 반환합니다.
+            return new FileResponseDTO(existingCodeFile.getFileUUID(), fileUrl);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserFileDTO> getUserFiles(String  userId) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + userId));
+
+        List<CodeFile> userCodeFiles = codeFileRepository.findByUser(user);
+
+        return userCodeFiles.stream()
+                .map(codeFile -> UserFileDTO.builder()
+                        .fileUUID(codeFile.getFileUUID())
+                        .originalFileName(codeFile.getOriginalFileName())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/dmu/debug_visual/file_upload/service/S3Uploader.java
+++ b/src/main/java/com/dmu/debug_visual/file_upload/service/S3Uploader.java
@@ -1,25 +1,14 @@
 package com.dmu.debug_visual.file_upload.service;
 
-import com.dmu.debug_visual.file_upload.S3FileDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.S3Object;
 
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
-
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.List;
-import java.util.stream.Collectors;
 import java.io.IOException;
-import java.util.UUID;
-
 
 @Service
 @RequiredArgsConstructor
@@ -30,59 +19,23 @@ public class S3Uploader {
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String upload(MultipartFile file, String dirName) throws IOException {
-        // 1. 고유한 파일 이름 생성
-        String originalFilename = file.getOriginalFilename();
-        String uniqueFileName = dirName + "/" + UUID.randomUUID().toString() + "_" + originalFilename;
-
-        // 2. S3에 업로드할 요청 객체 생성
+    /**
+     * S3에 파일을 업로드(또는 덮어쓰기)하고 URL을 반환합니다.
+     * 이제 이 메소드는 파일 경로를 직접 만들지 않고, 파라미터로 받습니다.
+     */
+    public String upload(MultipartFile file, String s3FilePath) throws IOException {
+        // 1. S3에 업로드할 요청 객체 생성 (전달받은 s3FilePath를 key로 사용)
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucket)
-                .key(uniqueFileName)
+                .key(s3FilePath) // UUID로 새로 만드는 대신, 전달받은 경로를 그대로 사용
                 .contentType(file.getContentType())
                 .contentLength(file.getSize())
                 .build();
 
-        // 3. 파일의 InputStream을 RequestBody로 만들어 S3에 업로드
+        // 2. 파일의 InputStream을 RequestBody로 만들어 S3에 업로드
         s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
 
-        // 4. 업로드된 파일의 URL 반환
-        return s3Client.utilities().getUrl(builder -> builder.bucket(bucket).key(uniqueFileName)).toString();
-    }
-
-    /**
-     * 특정 사용자의 모든 파일 목록을 S3에서 조회합니다.
-     * @param userId 조회할 사용자의 ID
-     * @return 파일 정보 DTO 리스트
-     */
-    public List<S3FileDTO> listFiles(String userId) {
-        // 1. 조회할 폴더(prefix)를 지정합니다. (예: "test-codes/")
-        String prefix = userId + "-codes/";
-
-        // 2. S3 객체 목록을 요청하기 위한 객체를 생성합니다.
-        ListObjectsV2Request listObjectsV2Request = ListObjectsV2Request.builder()
-                .bucket(bucket)
-                .prefix(prefix)
-                .build();
-
-        // 3. S3 클라이언트로 객체 목록을 조회합니다.
-        ListObjectsV2Response response = s3Client.listObjectsV2(listObjectsV2Request);
-        List<S3Object> s3Objects = response.contents();
-
-        // 4. 조회된 S3Object 목록을 우리가 만든 S3FileDTO 리스트로 변환합니다.
-        return s3Objects.stream()
-                .map(s3Object -> {
-                    String fullKey = s3Object.key();
-                    // "test-codes/UUID_원본파일이름" 에서 "원본파일이름"만 추출
-                    String originalFileName = fullKey.substring(fullKey.indexOf('_') + 1);
-
-                    return S3FileDTO.builder()
-                            .fileName(originalFileName)
-                            .fileUrl(s3Client.utilities().getUrl(builder -> builder.bucket(bucket).key(fullKey)).toString())
-                            .uploadDate(LocalDateTime.ofInstant(s3Object.lastModified(), ZoneId.systemDefault()))
-                            .fileSize(s3Object.size())
-                            .build();
-                })
-                .collect(Collectors.toList());
+        // 3. 업로드된 파일의 URL 반환
+        return s3Client.utilities().getUrl(builder -> builder.bucket(bucket).key(s3FilePath)).toString();
     }
 }


### PR DESCRIPTION
## 📋 PR 개요
파일 수정 시 S3에 새 파일을 생성하는 대신, 데이터베이스와 연동하여 기존 파일을 덮어쓰는 기능을 구현합니다.

---

## 💻 주요 변경 사항
- **데이터베이스 모델링**:
  - 파일의 고유 ID(`fileUUID`), 원본 파일명, S3 경로, 소유자 정보를 관리하는 `CodeFile` 엔티티를 추가했습니다.
  - `CodeFileRepository`를 추가하여 `fileUUID` 및 `User` 기반의 조회 기능을 구현했습니다.

- **서비스 로직 개편**:
  - 기존 `S3Uploader`의 역할을 S3 파일 업로드 및 URL 반환으로 단순화했습니다.
  - DB 연동 및 비즈니스 로직을 처리하는 `FileService`를 신규 생성하여 역할을 명확히 분리했습니다.
  - `FileService`에 `fileUUID` 유무에 따라 **신규 생성**과 **덮어쓰기** 로직을 분기하는 `saveOrUpdateFile` 메소드를 구현했습니다.

- **API 수정**:
  - `FileController`의 `/upload` 엔드포인트가 `fileUUID` (optional) 파라미터를 받도록 수정하고, `FileService`를 호출하도록 로직을 변경했습니다.
  - `GET /my` 엔드포인트가 S3를 직접 조회하는 대신, DB에 저장된 `CodeFile` 목록을 조회하도록 변경했습니다.

- **DTO 및 설정 추가**:
  - API 응답 객체인 `FileResponseDTO`와 `UserFileDTO`를 추가하여 응답 형식을 통일했습니다.
  - `SwaggerConfig`에 JWT `Bearer Auth` 인증 설정을 추가하여 API 테스트 편의성을 향상시켰습니다.

---

## 🔗 관련 이슈
- Closes #32 