### PR TITLE
feat: 세션 단위 권한 관리 및 생명주기 제어 기능 추가(#36)

### DIFF
--- a/src/main/java/com/dmu/debug_visual/collab/domain/entity/CodeSession.java
+++ b/src/main/java/com/dmu/debug_visual/collab/domain/entity/CodeSession.java
@@ -5,6 +5,10 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -26,10 +30,28 @@ public class CodeSession {
     @JoinColumn(name = "room_id", nullable = false)
     private Room room; // 이 세션이 속한 방
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'ACTIVE'") // DB에 기본값을 'ACTIVE'로 설정
+    private SessionStatus status;
+
+    public enum SessionStatus {
+        ACTIVE,  // 활성화 (방송 중)
+        INACTIVE // 비활성화 (방송 꺼짐)
+    }
+
     @Builder
     public CodeSession(String sessionName, Room room) {
         this.sessionId = UUID.randomUUID().toString();
         this.sessionName = sessionName;
         this.room = room;
+        this.status = SessionStatus.ACTIVE;
     }
+
+    public void updateStatus(SessionStatus status) {
+        this.status = status;
+    }
+
+    @OneToMany(mappedBy = "codeSession", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SessionParticipant> participants = new ArrayList<>();
 }

--- a/src/main/java/com/dmu/debug_visual/collab/domain/entity/SessionParticipant.java
+++ b/src/main/java/com/dmu/debug_visual/collab/domain/entity/SessionParticipant.java
@@ -1,0 +1,46 @@
+package com.dmu.debug_visual.collab.domain.entity;
+
+import com.dmu.debug_visual.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SessionParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "code_session_id", nullable = false)
+    private CodeSession codeSession;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Permission permission;
+
+    public enum Permission {
+        READ_ONLY,
+        READ_WRITE
+    }
+
+    public void updatePermission(Permission permission) {
+     this.permission = permission;
+    }
+
+    @Builder
+    public SessionParticipant(CodeSession codeSession, User user, Permission permission) {
+        this.codeSession = codeSession;
+        this.user = user;
+        this.permission = permission;
+    }
+}

--- a/src/main/java/com/dmu/debug_visual/collab/domain/repository/CodeSessionRepository.java
+++ b/src/main/java/com/dmu/debug_visual/collab/domain/repository/CodeSessionRepository.java
@@ -3,5 +3,8 @@ package com.dmu.debug_visual.collab.domain.repository;
 import com.dmu.debug_visual.collab.domain.entity.CodeSession;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CodeSessionRepository extends JpaRepository<CodeSession, Long> {
+    Optional<CodeSession> findBySessionId(String sessionId);
 }

--- a/src/main/java/com/dmu/debug_visual/collab/domain/repository/SessionParticipantRepository.java
+++ b/src/main/java/com/dmu/debug_visual/collab/domain/repository/SessionParticipantRepository.java
@@ -1,0 +1,19 @@
+package com.dmu.debug_visual.collab.domain.repository;
+
+import com.dmu.debug_visual.collab.domain.entity.SessionParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface SessionParticipantRepository extends JpaRepository<SessionParticipant, Long> {
+    // ✨ 세션 ID와 유저 ID로 참여 정보를 찾는 메소드
+    Optional<SessionParticipant> findByCodeSession_SessionIdAndUser_UserId(String sessionId, String userId);
+
+    // ✨ 강퇴 기능을 위해 특정 방의 모든 세션에서 특정 유저를 삭제하는 메소드
+    @Modifying
+    @Query("DELETE FROM SessionParticipant sp WHERE sp.codeSession.room.roomId = :roomId AND sp.user.userId = :userId")
+    void deleteAllByRoomIdAndUserId(@Param("roomId") String roomId, @Param("userId") String userId);
+}

--- a/src/main/java/com/dmu/debug_visual/collab/service/RoomService.java
+++ b/src/main/java/com/dmu/debug_visual/collab/service/RoomService.java
@@ -1,7 +1,10 @@
 package com.dmu.debug_visual.collab.service;
 
 import com.dmu.debug_visual.collab.domain.entity.CodeSession;
+import com.dmu.debug_visual.collab.domain.entity.CodeSession.SessionStatus;
+import com.dmu.debug_visual.collab.domain.entity.SessionParticipant;
 import com.dmu.debug_visual.collab.domain.repository.CodeSessionRepository;
+import com.dmu.debug_visual.collab.domain.repository.SessionParticipantRepository;
 import com.dmu.debug_visual.user.User;
 import com.dmu.debug_visual.user.UserRepository;
 import com.dmu.debug_visual.collab.domain.repository.RoomParticipantRepository;
@@ -17,6 +20,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 협업 방과 세션의 생성, 관리, 권한 부여 등 핵심 비즈니스 로직을 처리하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class RoomService {
@@ -24,22 +30,27 @@ public class RoomService {
     private final RoomRepository roomRepository;
     private final UserRepository userRepository;
     private final RoomParticipantRepository roomParticipantRepository;
+    private final SessionParticipantRepository sessionParticipantRepository;
     private final CodeSessionRepository codeSessionRepository;
 
+    // 1. 방 관리 (Room Management)
+    /**
+     * 새로운 협업 방을 생성하고, 생성자를 방장 및 첫 참여자로 등록합니다.
+     * @param request 방 이름이 담긴 요청 DTO
+     * @param ownerUserId 방을 생성하는 사용자의 ID
+     * @return 생성된 방의 정보가 담긴 응답 DTO
+     */
     @Transactional
     public RoomResponse createRoom(CreateRoomRequest request, String ownerUserId) {
-        // 1. 방을 생성할 유저(방장) 정보를 DB에서 조회
         User owner = userRepository.findByUserId(ownerUserId)
-                .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + ownerUserId));
+                .orElseThrow(() -> new EntityNotFoundException("User not found: " + ownerUserId));
 
-        // 2. 새로운 Room 엔티티 생성 및 저장
         Room newRoom = Room.builder()
                 .name(request.getRoomName())
                 .owner(owner)
                 .build();
         roomRepository.save(newRoom);
 
-        // 3. 방장(Owner)을 첫 참여자로 등록 (권한은 READ_WRITE)
         RoomParticipant ownerParticipant = RoomParticipant.builder()
                 .room(newRoom)
                 .user(owner)
@@ -47,43 +58,166 @@ public class RoomService {
                 .build();
         roomParticipantRepository.save(ownerParticipant);
 
-        // 4. 기본 코드 세션("main") 생성
-        CodeSession defaultSession = CodeSession.builder()
-                .sessionName("main") // 기본 세션 이름
-                .room(newRoom)
-                .build();
-        codeSessionRepository.save(defaultSession);
-
-        // 5. 응답 DTO를 만들어 반환
         return RoomResponse.builder()
                 .roomId(newRoom.getRoomId())
                 .roomName(newRoom.getName())
                 .ownerId(owner.getUserId())
-                .defaultSessionId(defaultSession.getSessionId())
                 .build();
     }
 
+    /**
+     * 방장이 특정 참가자를 방에서 강퇴시킵니다.
+     * @param roomId 대상 방의 ID
+     * @param ownerId 요청을 보낸 방장의 ID
+     * @param targetUserId 강퇴될 참가자의 ID
+     */
+    @Transactional
+    public void kickParticipant(String roomId, String ownerId, String targetUserId) {
+        Room room = roomRepository.findByRoomId(roomId)
+                .orElseThrow(() -> new EntityNotFoundException("Room not found: " + roomId));
+
+        if (!room.getOwner().getUserId().equals(ownerId)) {
+            throw new IllegalStateException("Only the room owner can kick participants.");
+        }
+        if (ownerId.equals(targetUserId)) {
+            throw new IllegalArgumentException("Owner cannot kick themselves.");
+        }
+
+        // 1. 방 참여자 목록에서 삭제
+        RoomParticipant participantToRemove = roomParticipantRepository.findByRoomAndUser_UserId(room, targetUserId)
+                .orElseThrow(() -> new EntityNotFoundException("Participant not found in this room."));
+        roomParticipantRepository.delete(participantToRemove);
+
+        // 2. 해당 방의 모든 세션 참여자 목록에서도 삭제
+        sessionParticipantRepository.deleteAllByRoomIdAndUserId(roomId, targetUserId);
+    }
+
+    // 2. 세션 관리 (Session Management)
+
+    /**
+     * 특정 방 안에 새로운 코드 세션을 생성합니다. (방송 시작)
+     * 세션 생성자는 READ_WRITE, 나머지 방 멤버는 READ_ONLY 권한을 자동으로 부여받습니다.
+     * @param roomId 세션을 생성할 방의 ID
+     * @param request 세션 이름이 담긴 요청 DTO
+     * @param creatorUserId 세션을 생성하는 사용자의 ID
+     * @return 생성된 세션의 정보가 담긴 응답 DTO
+     */
     @Transactional
     public SessionResponse createCodeSessionInRoom(String roomId, CreateSessionRequest request, String creatorUserId) {
-        // 1. roomId로 해당 방을 DB에서 조회
         Room room = roomRepository.findByRoomId(roomId)
-                .orElseThrow(() -> new EntityNotFoundException("Room not found with id: " + roomId));
+                .orElseThrow(() -> new EntityNotFoundException("Room not found: " + roomId));
+        User creator = userRepository.findByUserId(creatorUserId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found: " + creatorUserId));
 
-        // 2. (보안) 요청자가 해당 방의 참여자인지 확인
-        roomParticipantRepository.findByRoomAndUser_UserId(room, creatorUserId)
-                .orElseThrow(() -> new IllegalStateException("You are not a participant of this room."));
-
-        // 3. 새로운 CodeSession 엔티티 생성
         CodeSession newSession = CodeSession.builder()
                 .sessionName(request.getSessionName())
                 .room(room)
                 .build();
         codeSessionRepository.save(newSession);
 
-        // 4. 응답 DTO를 만들어 반환
+        // 세션 생성자에게는 쓰기 권한 부여
+        SessionParticipant creatorParticipant = SessionParticipant.builder()
+                .codeSession(newSession)
+                .user(creator)
+                .permission(SessionParticipant.Permission.READ_WRITE)
+                .build();
+        sessionParticipantRepository.save(creatorParticipant);
+
+        // 방에 있는 다른 모든 참여자에게는 읽기 전용 권한 부여
+        room.getParticipants().stream()
+                .map(RoomParticipant::getUser)
+                .filter(user -> !user.getUserId().equals(creatorUserId))
+                .forEach(participantUser -> {
+                    SessionParticipant readOnlyParticipant = SessionParticipant.builder()
+                            .codeSession(newSession)
+                            .user(participantUser)
+                            .permission(SessionParticipant.Permission.READ_ONLY)
+                            .build();
+                    sessionParticipantRepository.save(readOnlyParticipant);
+                });
+
         return SessionResponse.builder()
                 .sessionId(newSession.getSessionId())
                 .sessionName(newSession.getSessionName())
                 .build();
+    }
+
+    /**
+     * 세션의 상태를 변경합니다. (방송 켜기/끄기)
+     * @param sessionId 상태를 변경할 세션의 ID
+     * @param userId 요청을 보낸 사용자의 ID
+     * @param newStatus 변경할 새로운 상태 (ACTIVE / INACTIVE)
+     */
+    @Transactional
+    public void updateSessionStatus(String sessionId, String userId, SessionStatus newStatus) {
+        CodeSession session = findSessionAndVerifyCreator(sessionId, userId, "Only the session creator can change the status.");
+        session.updateStatus(newStatus);
+    }
+
+
+    // 3. 세션 권한 관리 (Permission Management)
+
+    /**
+     * 특정 세션에 대한 사용자의 쓰기 권한 여부를 확인합니다.
+     * @param sessionId 확인할 세션의 ID
+     * @param userId 확인할 사용자의 ID
+     * @return 쓰기 권한이 있으면 true, 아니면 false
+     */
+    @Transactional(readOnly = true)
+    public boolean hasWritePermissionInSession(String sessionId, String userId) {
+        return sessionParticipantRepository.findByCodeSession_SessionIdAndUser_UserId(sessionId, userId)
+                .map(participant -> participant.getPermission() == SessionParticipant.Permission.READ_WRITE)
+                .orElse(false);
+    }
+
+    /**
+     * 세션 생성자가 다른 참여자에게 쓰기 권한을 부여합니다.
+     * @param sessionId 권한을 부여할 세션의 ID
+     * @param requesterId 권한을 부여하는 사용자(생성자)의 ID
+     * @param targetUserId 권한을 받을 사용자의 ID
+     */
+    @Transactional
+    public void grantWritePermissionInSession(String sessionId, String requesterId, String targetUserId) {
+        findSessionAndVerifyCreator(sessionId, requesterId, "Only the session creator can grant permissions.");
+
+        SessionParticipant participant = sessionParticipantRepository.findByCodeSession_SessionIdAndUser_UserId(sessionId, targetUserId)
+                .orElseThrow(() -> new EntityNotFoundException("Participant not found in this session."));
+        participant.updatePermission(SessionParticipant.Permission.READ_WRITE);
+    }
+
+    /**
+     * 세션 생성자가 다른 참여자의 쓰기 권한을 회수합니다.
+     * @param sessionId 권한을 회수할 세션의 ID
+     * @param requesterId 권한을 회수하는 사용자(생성자)의 ID
+     * @param targetUserId 권한을 회수당할 사용자의 ID
+     */
+    @Transactional
+    public void revokeWritePermissionInSession(String sessionId, String requesterId, String targetUserId) {
+        CodeSession session = findSessionAndVerifyCreator(sessionId, requesterId, "Only the session creator can revoke permissions.");
+
+        if (requesterId.equals(targetUserId)) {
+            throw new IllegalArgumentException("Session creator cannot revoke their own permission.");
+        }
+
+        SessionParticipant participant = sessionParticipantRepository.findByCodeSession_SessionIdAndUser_UserId(sessionId, targetUserId)
+                .orElseThrow(() -> new EntityNotFoundException("Participant not found in this session."));
+        participant.updatePermission(SessionParticipant.Permission.READ_ONLY);
+    }
+
+    // Private Helper Methods
+
+    /**
+     * 세션을 찾고, 요청자가 해당 세션의 생성자인지 검증하는 private 헬퍼 메소드
+     */
+    private CodeSession findSessionAndVerifyCreator(String sessionId, String requesterId, String errorMessage) {
+        CodeSession session = codeSessionRepository.findBySessionId(sessionId)
+                .orElseThrow(() -> new EntityNotFoundException("Session not found: " + sessionId));
+
+        // 세션의 첫 번째 참여자가 생성자라는 규칙을 활용
+        String creatorId = session.getParticipants().get(0).getUser().getUserId();
+        if (!creatorId.equals(requesterId)) {
+            throw new IllegalStateException(errorMessage);
+        }
+        return session;
     }
 }

--- a/src/main/java/com/dmu/debug_visual/collab/websocket/CodeCollabController.java
+++ b/src/main/java/com/dmu/debug_visual/collab/websocket/CodeCollabController.java
@@ -1,12 +1,8 @@
 package com.dmu.debug_visual.collab.websocket;
 
-import com.dmu.debug_visual.user.User;
-import com.dmu.debug_visual.collab.rest.dto.SystemMessage;
+import com.dmu.debug_visual.collab.service.RoomService;
 import com.dmu.debug_visual.user.UserRepository;
 import com.dmu.debug_visual.collab.websocket.dto.CodeMessage;
-import com.dmu.debug_visual.collab.rest.dto.PermissionChangeMessage;
-import com.dmu.debug_visual.collab.websocket.dto.WebSocketRoom;
-import com.dmu.debug_visual.collab.service.WebSocketRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -14,15 +10,15 @@ import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Controller;
 
 /**
- * 실시간 협업 관련 WebSocket 메시지를 처리하는 컨트롤러
+ * 실시간 협업 관련 WebSocket 메시지만을 처리하는 컨트롤러
  */
 @Controller
 @RequiredArgsConstructor
 public class CodeCollabController {
 
-    private final WebSocketRoomService webSocketRoomService;
-    private final SimpMessageSendingOperations messagingTemplate;
+    private final RoomService roomService;
     private final UserRepository userRepository;
+    private final SimpMessageSendingOperations messagingTemplate;
 
     /**
      * 특정 코드 세션 내에서 발생하는 코드 수정 이벤트를 처리합니다.
@@ -34,61 +30,20 @@ public class CodeCollabController {
      * @param message   전송된 코드 정보 (senderId, content 등)
      */
     @MessageMapping("/room/{roomId}/session/{sessionId}/code-update")
-    public void handleCodeUpdate(@DestinationVariable String roomId, @DestinationVariable String sessionId, CodeMessage message) {
-        if (webSocketRoomService.hasWritePermission(roomId, message.getSenderId())) {
+    public void handleCodeUpdate(
+            @DestinationVariable String roomId,
+            @DestinationVariable String sessionId,
+            CodeMessage message) {
+
+        // 세션 단위로 권한을 검사합니다.
+        if (roomService.hasWritePermissionInSession(sessionId, message.getSenderId())) {
+            // 사용자 이름을 찾아서 메시지에 추가
             userRepository.findByUserId(message.getSenderId()).ifPresent(user -> {
                 message.setSenderName(user.getName());
             });
 
             String topic = String.format("/topic/room/%s/session/%s/code", roomId, sessionId);
             messagingTemplate.convertAndSend(topic, message);
-        }
-    }
-
-    /**
-     * 방장이 특정 참여자에게 쓰기 권한을 부여하는 이벤트를 처리합니다.
-     * 클라이언트는 이 주소('/app/room/{roomId}/grant-permission')로 PermissionChangeMessage를 발행(publish)합니다.
-     * 서버는 해당 방을 구독 중인 모든 클라이언트에게 권한 변경 사실을 브로드캐스팅합니다.
-     *
-     * @param roomId  현재 방의 고유 ID
-     * @param message 권한 변경 정보 (senderId, targetUserId 등)
-     */
-    @MessageMapping("/room/{roomId}/grant-permission")
-    public void handlePermissionGrant(@DestinationVariable String roomId, PermissionChangeMessage message) {
-        WebSocketRoom webSocketRoom = webSocketRoomService.findActiveRoomById(roomId);
-        if (webSocketRoom != null && webSocketRoom.getOwnerId().equals(message.getSenderId())) {
-            webSocketRoom.grantWritePermission(message.getTargetUserId());
-
-            userRepository.findByUserId(message.getSenderId()).ifPresent(sender -> message.setSenderName(sender.getName()));
-            userRepository.findByUserId(message.getTargetUserId()).ifPresent(target -> message.setTargetUserName(target.getName()));
-
-            messagingTemplate.convertAndSend("/topic/room/" + roomId + "/permission", message);
-        }
-    }
-
-    /**
-     * 방장이 특정 참여자의 쓰기 권한을 회수하는 이벤트를 처리합니다.
-     * @param roomId 현재 방의 고유 ID
-     * @param message 권한 변경 정보 (senderId, targetUserId)
-     */
-    @MessageMapping("/room/{roomId}/revoke-permission")
-    public void handlePermissionRevoke(@DestinationVariable String roomId, PermissionChangeMessage message) {
-        WebSocketRoom webSocketRoom = webSocketRoomService.findActiveRoomById(roomId);
-        // 방장(owner)만 권한을 회수할 수 있습니다.
-        if (webSocketRoom != null && webSocketRoom.getOwnerId().equals(message.getSenderId())) {
-            // 1. DTO의 권한 회수 메소드 호출
-            webSocketRoom.revokeWritePermission(message.getTargetUserId());
-
-            // 2. 알림 메시지를 위한 이름 조회
-            String senderName = userRepository.findByUserId(message.getSenderId()).map(User::getName).orElse("방장");
-            String targetUserName = userRepository.findByUserId(message.getTargetUserId()).map(User::getName).orElse("참여자");
-
-            // 3. 시스템 채널로 권한 회수 사실을 모두에게 알림
-            SystemMessage systemMessage = SystemMessage.builder()
-                    .content(senderName + "님이 " + targetUserName + "님의 쓰기 권한을 회수했습니다.")
-                    .build();
-
-            messagingTemplate.convertAndSend("/topic/room/" + roomId + "/system", systemMessage);
         }
     }
 }


### PR DESCRIPTION
## 📋 PR 개요
협업 기능의 권한 관리 체계를 세션 단위로 이전하고, 세션의 활성화/비활성화 및 참가자 강퇴 등 포괄적인 관리 기능을 위한 **핵심 서비스 로직**을 구현합니다.

---

## 💻 주요 변경 사항
- **데이터베이스 모델링**:
  - `SessionParticipant` 엔티티를 신규 생성하여 세션별 참여자와 권한을 관리할 수 있는 기반을 마련했습니다.
  - `CodeSession` 엔티티에 `SessionStatus` (`ACTIVE`/`INACTIVE`) 필드를 추가하여 세션의 활성화 상태를 저장할 수 있도록 확장했습니다.

- **서비스 로직 구현 (핵심 변경 사항)**:
  - **세션 관리 기능 추가**: `RoomService`에 세션 생성자가 세션의 상태를 변경(`updateSessionStatus`)하는 메소드를 구현했습니다.
  - **세션 단위 권한 관리 기능 추가**: 세션 생성자가 다른 참여자의 쓰기 권한을 부여(`grantWritePermissionInSession`)하거나 회수(`revokeWritePermissionInSession`)하는 메소드를 `RoomService`에 구현했습니다.
  - **강퇴 기능 추가**: 방장이 특정 참가자를 방과 관련된 모든 세션에서 한 번에 제거하는 `kickParticipant` 메소드를 `RoomService`에 구현했습니다.

- **WebSocket 권한 검사 수정**:
  - `CodeCollabController`가 DB를 직접 조회하는 `hasWritePermissionInSession` 서비스 메소드를 호출하도록 변경하여, 세션 단위의 쓰기 권한을 정확히 검사하도록 수정했습니다.

- **⚠️ 다음 작업 예정 (To-Do)**:
  - 현재 `RoomController`에는 위에서 구현된 새로운 서비스 로직들을 호출하는 **REST API 엔드포인트가 아직 적용되지 않았습니다.**
  - 다음 커밋에서 관련 API(`세션 상태 변경`, `권한 부여/회수`, `강퇴`)를 `RoomController`에 추가할 예정입니다.

---

## 🔗 관련 이슈
- In progress #36 