### PR TITLE
feat: 실시간 참여자 목록 동기화 및 세션 관리 API 연동(#36)

### DIFF
--- a/src/main/java/com/dmu/debug_visual/collab/rest/RoomController.java
+++ b/src/main/java/com/dmu/debug_visual/collab/rest/RoomController.java
@@ -1,5 +1,6 @@
 package com.dmu.debug_visual.collab.rest;
 
+import com.dmu.debug_visual.collab.domain.entity.CodeSession.SessionStatus;
 import com.dmu.debug_visual.security.CustomUserDetails;
 import com.dmu.debug_visual.collab.rest.dto.CreateRoomRequest;
 import com.dmu.debug_visual.collab.rest.dto.CreateSessionRequest;
@@ -18,48 +19,109 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "협업 방 및 세션 관리 API", description = "실시간 협업을 위한 방과 코드 세션을 생성하고 관리합니다.")
+import java.util.Map;
+
+@Tag(name = "협업 방 및 세션 관리 API", description = "실시간 협업을 위한 방 생성, 세션 관리, 권한 부여, 강퇴 등 모든 REST API를 제공합니다.")
 @RestController
-@RequestMapping("/api/collab-rooms")
+@RequestMapping("/api/collab")
 @RequiredArgsConstructor
 public class RoomController {
 
-    private final RoomService roomService; // DB 관련 서비스
+    private final RoomService roomService;
 
-    @Operation(summary = "새로운 협업 방 생성", description = "DB에 새로운 협업 방을 생성하고, 방장(owner)을 첫 참여자로 자동 등록합니다.")
+    // --- 방 관리 ---
+    @Operation(summary = "새로운 협업 방 생성", description = "DB에 새로운 협업 방을 생성하고, 방장을 첫 참여자로 자동 등록합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "방 생성 성공",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = RoomResponse.class))),
+            @ApiResponse(responseCode = "200", description = "방 생성 성공", content = @Content(schema = @Schema(implementation = RoomResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     })
-    @PostMapping
-    public ResponseEntity<RoomResponse> createRoom(
-            @RequestBody CreateRoomRequest request,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+    @PostMapping("/rooms")
+    public ResponseEntity<RoomResponse> createRoom(@RequestBody CreateRoomRequest request, @AuthenticationPrincipal CustomUserDetails userDetails) {
         String ownerUserId = userDetails.getUsername();
         RoomResponse response = roomService.createRoom(request, ownerUserId);
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "방 안에 새 코드 세션 생성", description = "기존에 생성된 협업 방 안에 독립적인 새 코드 편집 세션을 생성합니다.")
+    @Operation(summary = "방에서 참가자 강퇴 (방장 전용)", description = "방장이 특정 참가자를 방에서 영구적으로 제외시킵니다. 강퇴된 참가자는 해당 방의 모든 세션에서도 제거됩니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "세션 생성 성공",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = SessionResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
-            @ApiResponse(responseCode = "403", description = "해당 방의 참여자가 아님", content = @Content),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 방", content = @Content)
+            @ApiResponse(responseCode = "200", description = "강퇴 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (방장이 아님)"),
+            @ApiResponse(responseCode = "404", description = "방 또는 참가자를 찾을 수 없음")
     })
-    @PostMapping("/{roomId}/sessions")
-    public ResponseEntity<SessionResponse> createSession(
-            @Parameter(description = "세션을 생성할 방의 고유 ID (UUID)", required = true)
-            @PathVariable String roomId,
+    @DeleteMapping("/rooms/{roomId}/participants/{targetUserId}")
+    public ResponseEntity<Void> kickParticipant(
+            @Parameter(description = "대상 방의 고유 ID") @PathVariable String roomId,
+            @Parameter(description = "강퇴시킬 사용자의 ID") @PathVariable String targetUserId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        roomService.kickParticipant(roomId, userDetails.getUsername(), targetUserId);
+        return ResponseEntity.ok().build();
+    }
 
+    // --- 세션 관리 ---
+    @Operation(summary = "방 안에 새 코드 세션 생성 (방송 시작)", description = "기존 방 안에 독립적인 새 코드 편집 세션을 생성합니다. 생성자는 자동으로 쓰기 권한을 가집니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "세션 생성 성공", content = @Content(schema = @Schema(implementation = SessionResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 방")
+    })
+    @PostMapping("/rooms/{roomId}/sessions")
+    public ResponseEntity<SessionResponse> createSession(
+            @Parameter(description = "세션을 생성할 방의 고유 ID") @PathVariable String roomId,
             @RequestBody CreateSessionRequest request,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         String creatorUserId = userDetails.getUsername();
         SessionResponse response = roomService.createCodeSessionInRoom(roomId, request, creatorUserId);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "세션 상태 변경 (방송 켜기/끄기, 세션 생성자 전용)", description = "세션의 상태를 'ACTIVE' 또는 'INACTIVE'로 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "상태 변경 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (세션 생성자가 아님)"),
+            @ApiResponse(responseCode = "404", description = "세션을 찾을 수 없음")
+    })
+    @PatchMapping("/sessions/{sessionId}/status")
+    public ResponseEntity<Void> updateSessionStatus(
+            @Parameter(description = "상태를 변경할 세션의 고유 ID") @PathVariable String sessionId,
+            @RequestBody Map<String, SessionStatus> statusMap,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        roomService.updateSessionStatus(sessionId, userDetails.getUsername(), statusMap.get("status"));
+        return ResponseEntity.ok().build();
+    }
+
+    // --- 세션 권한 관리 ---
+    @Operation(summary = "세션 내 쓰기 권한 부여 (세션 생성자 전용)", description = "세션 생성자가 특정 참가자에게 해당 세션의 쓰기 권한을 부여합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "권한 부여 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (세션 생성자가 아님)"),
+            @ApiResponse(responseCode = "404", description = "세션 또는 참가자를 찾을 수 없음")
+    })
+    @PostMapping("/sessions/{sessionId}/permissions/{targetUserId}")
+    public ResponseEntity<Void> grantWritePermission(
+            @Parameter(description = "권한을 부여할 세션의 고유 ID") @PathVariable String sessionId,
+            @Parameter(description = "권한을 부여받을 사용자의 ID") @PathVariable String targetUserId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        roomService.grantWritePermissionInSession(sessionId, userDetails.getUsername(), targetUserId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "세션 내 쓰기 권한 회수 (세션 생성자 전용)", description = "세션 생성자가 특정 참가자의 쓰기 권한을 회수합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "권한 회수 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (세션 생성자가 아님)"),
+            @ApiResponse(responseCode = "404", description = "세션 또는 참가자를 찾을 수 없음")
+    })
+    @DeleteMapping("/sessions/{sessionId}/permissions/{targetUserId}")
+    public ResponseEntity<Void> revokeWritePermission(
+            @Parameter(description = "권한을 회수할 세션의 고유 ID") @PathVariable String sessionId,
+            @Parameter(description = "권한을 회수당할 사용자의 ID") @PathVariable String targetUserId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        roomService.revokeWritePermissionInSession(sessionId, userDetails.getUsername(), targetUserId);
+        return ResponseEntity.ok().build();
+    }
 }
+

--- a/src/main/java/com/dmu/debug_visual/collab/rest/dto/ParticipantInfo.java
+++ b/src/main/java/com/dmu/debug_visual/collab/rest/dto/ParticipantInfo.java
@@ -1,0 +1,14 @@
+package com.dmu.debug_visual.collab.rest.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 참여자 한 명의 정보를 담는 DTO
+ */
+@Getter
+@Builder
+public class ParticipantInfo {
+    private String userId;
+    private String userName;
+}

--- a/src/main/java/com/dmu/debug_visual/collab/rest/dto/RoomStateUpdate.java
+++ b/src/main/java/com/dmu/debug_visual/collab/rest/dto/RoomStateUpdate.java
@@ -1,0 +1,18 @@
+package com.dmu.debug_visual.collab.rest.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 방의 최신 상태(방 이름, 방장, 참여자 목록) 정보를 담는 DTO.
+ * 사용자가 입장/퇴장할 때마다 이 객체가 /topic/room/{roomId}/system 으로 전송됩니다.
+ */
+@Getter
+@Builder
+public class RoomStateUpdate {
+    private String roomName;
+    private ParticipantInfo owner; // 방장 정보
+    private List<ParticipantInfo> participants; // 참여자 목록 (방장을 제외한 나머지)
+}

--- a/src/main/java/com/dmu/debug_visual/collab/service/WebSocketRoomService.java
+++ b/src/main/java/com/dmu/debug_visual/collab/service/WebSocketRoomService.java
@@ -35,7 +35,6 @@ public class WebSocketRoomService {
      * @param roomId 찾으려는 방의 ID
      * @return 찾아낸 방의 정보 (없으면 null)
      */
-    // ✨ 이 메소드 이름을 수정해주세요!
     public WebSocketRoom findActiveRoomById(String roomId) {
         return activeRooms.get(roomId);
     }
@@ -64,6 +63,13 @@ public class WebSocketRoomService {
         WebSocketRoom webSocketRoom = findActiveRoomById(roomId);
         if (webSocketRoom != null) {
             webSocketRoom.addParticipant(userId);
+        }
+    }
+
+    public void removeParticipant(String roomId, String userId) {
+        WebSocketRoom activeRoom = findActiveRoomById(roomId);
+        if (activeRoom != null) {
+            activeRoom.getParticipants().remove(userId);
         }
     }
 }

--- a/src/main/java/com/dmu/debug_visual/config/WebSocketEventListener.java
+++ b/src/main/java/com/dmu/debug_visual/config/WebSocketEventListener.java
@@ -2,9 +2,9 @@ package com.dmu.debug_visual.config;
 
 import com.dmu.debug_visual.collab.domain.entity.Room;
 import com.dmu.debug_visual.collab.domain.repository.RoomRepository;
-import com.dmu.debug_visual.collab.rest.dto.SystemMessage;
+import com.dmu.debug_visual.collab.rest.dto.ParticipantInfo;
+import com.dmu.debug_visual.collab.rest.dto.RoomStateUpdate;
 import com.dmu.debug_visual.collab.service.WebSocketRoomService;
-import com.dmu.debug_visual.collab.websocket.dto.WebSocketRoom;
 import com.dmu.debug_visual.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,8 +18,10 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
 import java.security.Principal;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -28,52 +30,33 @@ public class WebSocketEventListener {
 
     private final SimpMessageSendingOperations messagingTemplate;
     private final WebSocketRoomService webSocketRoomService;
-    private final RoomRepository roomRepository; // ✨ DB 조회를 위해 RoomRepository 주입
+    private final RoomRepository roomRepository;
 
     @EventListener
     @Transactional
     public void handleWebSocketSubscribeListener(SessionSubscribeEvent event) {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
         Principal userPrincipal = headerAccessor.getUser();
-
-        if (userPrincipal == null) {
-            log.warn("Cannot process subscribe: user not authenticated.");
-            return;
-        }
+        if (userPrincipal == null) return;
 
         String destination = headerAccessor.getDestination();
         if (destination != null && destination.contains("/topic/room/")) {
             try {
                 String roomId = destination.split("/")[3];
 
-                // ✨ 1. 메모리에 활성화된 방이 있는지 확인
-                WebSocketRoom activeRoom = webSocketRoomService.findActiveRoomById(roomId);
-                if (activeRoom == null) {
-                    // ✨ 2. 없다면, DB에서 방 정보를 가져와서 "파티 시작" (메모리에 활성화)
-                    log.info("Activating room {} in memory.", roomId);
-                    Room dbRoom = roomRepository.findByRoomId(roomId)
-                            .orElseThrow(() -> new RuntimeException("Subscribing to a non-existent room: " + roomId));
-                    // WebSocket 서비스에 방을 활성화하도록 요청 (방장 정보와 함께)
-                    webSocketRoomService.activateRoom(roomId, dbRoom.getOwner().getUserId());
-                }
-
-                // ✨ 3. 이제 사용자를 활성화된 방에 참여시킴
+                // --- 사용자 정보 가져오기 및 메모리에 사용자 추가 ---
                 Authentication authentication = (Authentication) userPrincipal;
                 CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
                 String userId = userDetails.getUsername();
-                String userName = userDetails.getUser().getName();
-
                 webSocketRoomService.addParticipant(roomId, userId);
 
-                // ✨ 4. 퇴장 이벤트를 위해 세션에 정보 저장
+                // --- 퇴장 이벤트를 위해 세션에 정보 저장 ---
                 Map<String, Object> sessionAttributes = Objects.requireNonNull(headerAccessor.getSessionAttributes());
                 sessionAttributes.put("roomId", roomId);
-                sessionAttributes.put("userName", userName);
+                sessionAttributes.put("userId", userId);
 
-                log.info("[입장] 사용자: {}, 방: {}", userName, roomId);
-                SystemMessage systemMessage = SystemMessage.builder().content(userName + "님이 입장했습니다.").build();
-
-                messagingTemplate.convertAndSend("/topic/room/" + roomId + "/system", systemMessage);
+                // --- 방 전체에 최신 상태 브로드캐스팅 ---
+                broadcastRoomState(roomId);
 
             } catch (Exception e) {
                 log.error("Error handling subscribe event: ", e);
@@ -82,19 +65,59 @@ public class WebSocketEventListener {
     }
 
     @EventListener
+    @Transactional
     public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
         Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
 
         if (sessionAttributes != null) {
-            String userName = (String) sessionAttributes.get("userName");
             String roomId = (String) sessionAttributes.get("roomId");
+            String userId = (String) sessionAttributes.get("userId");
 
-            if (userName != null && roomId != null) {
-                log.info("[퇴장] 사용자: {}, 방: {}", userName, roomId);
-                SystemMessage systemMessage = SystemMessage.builder().content(userName + "님이 퇴장했습니다.").build();
-                messagingTemplate.convertAndSend("/topic/room/" + roomId + "/system", systemMessage);
+            if (roomId != null && userId != null) {
+                log.info("[퇴장] 사용자: {}, 방: {}", userId, roomId);
+
+                // 메모리에서 사용자 제거 (WebSocketRoomService에 removeParticipant 메소드 필요)
+                webSocketRoomService.removeParticipant(roomId, userId);
+
+                // --- 방 전체에 최신 상태 브로드캐스팅 ---
+                broadcastRoomState(roomId);
             }
         }
+    }
+
+    /**
+     * 특정 방의 최신 상태(방 이름, 방장, 참여자 목록)를 조회하여
+     * 해당 방의 시스템 채널로 브로드캐스팅하는 헬퍼 메소드
+     */
+    private void broadcastRoomState(String roomId) {
+        Room dbRoom = roomRepository.findByRoomId(roomId)
+                .orElseThrow(() -> new RuntimeException("Room not found during state broadcast: " + roomId));
+
+        // 1. 방장 정보 DTO 생성
+        ParticipantInfo ownerInfo = ParticipantInfo.builder()
+                .userId(dbRoom.getOwner().getUserId())
+                .userName(dbRoom.getOwner().getName())
+                .build();
+
+        // 2. 참여자(방장 제외) 목록 DTO 생성
+        List<ParticipantInfo> participantInfos = dbRoom.getParticipants().stream()
+                .filter(p -> !p.getUser().getUserId().equals(dbRoom.getOwner().getUserId()))
+                .map(p -> ParticipantInfo.builder()
+                        .userId(p.getUser().getUserId())
+                        .userName(p.getUser().getName())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 3. 최종 업데이트 DTO 생성
+        RoomStateUpdate roomStateUpdate = RoomStateUpdate.builder()
+                .roomName(dbRoom.getName())
+                .owner(ownerInfo)
+                .participants(participantInfos)
+                .build();
+
+        // 4. 시스템 채널로 브로드캐스팅
+        messagingTemplate.convertAndSend("/topic/room/" + roomId + "/system", roomStateUpdate);
+        log.info("Broadcasted room state update for room: {}", roomId);
     }
 }

--- a/src/main/resources/template/test.html
+++ b/src/main/resources/template/test.html
@@ -5,37 +5,45 @@
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
     <style>
-        body { font-family: sans-serif; display: flex; gap: 20px; padding: 10px; }
+        body { font-family: sans-serif; display: flex; flex-wrap: wrap; gap: 20px; padding: 10px; }
         .panel { border: 1px solid #ccc; padding: 10px; border-radius: 5px; min-width: 300px; }
-        textarea { width: 400px; height: 300px; }
+        textarea { width: 400px; height: 300px; resize: vertical; }
         #log { width: 400px; height: 400px; overflow-y: scroll; border: 1px solid #eee; padding: 5px; font-size: 12px; background-color: #f9f9f9; white-space: pre-wrap; }
+        #participantsPanel { height: 400px; }
+        #participantList { list-style: none; padding: 0; }
+        #participantList li { padding: 5px; border-bottom: 1px solid #eee; }
+        #participantList .owner { font-weight: bold; color: #b45309; }
         input { margin-bottom: 5px; padding: 4px; width: 95%; }
-        button { width: 100%; padding: 8px; margin-top: 5px; }
+        button { width: 100%; padding: 8px; margin-top: 5px; cursor: pointer; }
     </style>
 </head>
 <body>
+
 <div class="panel">
-    <h2>Connection</h2>
-    <input type="text" id="roomId" placeholder="Enter Room ID"><br>
-    <input type="text" id="sessionId" placeholder="Enter Session ID"> <input type="text" id="myUserId" placeholder="Enter My User ID"><br>
-    <input type="text" id="jwtToken" placeholder="Enter JWT Token" style="width: 95%;"><br>
+    <h2>1. Connection</h2>
+    <input type="text" id="roomId" placeholder="Enter Room ID">
+    <input type="text" id="sessionId" placeholder="Enter Session ID">
+    <input type="text" id="myUserId" placeholder="Enter My User ID">
+    <input type="text" id="jwtToken" placeholder="Enter JWT Token">
     <button onclick="connect()">Connect</button>
-    <button onclick="disconnect()">Disconnect</button>
-    <hr>
-    <h2>Grant Permission</h2>
-    <input type="text" id="targetUserId" placeholder="Target User ID"><br>
-    <button onclick="grantPermission()">Grant Write Permission</button>
-    <hr>
-    <h2>Revoke Permission</h2>
-    <input type="text" id="revokeTargetUserId" placeholder="Target User ID"><br>
-    <button onclick="revokePermission()">Revoke Write Permission</button>
+    <button onclick="disconnect()" disabled>Disconnect</button>
+    <p style="font-size: 12px; color: #666;">
+        <b>Note:</b> 권한 부여/회수, 강퇴, 세션 켜고 끄기는 REST API로 처리됩니다. (API 명세서 참고)
+    </p>
 </div>
-<div class="panel">
-    <h2>Code Editor</h2>
-    <textarea id="editor" onkeyup="sendCodeUpdate()"></textarea>
+
+<div class="panel" id="participantsPanel">
+    <h2 id="roomNameTitle">Participants</h2>
+    <ul id="participantList"></ul>
 </div>
+
 <div class="panel">
-    <h2>Received Messages Log</h2>
+    <h2>2. Code Editor (Session)</h2>
+    <textarea id="editor" onkeyup="sendCodeUpdate()" disabled></textarea>
+</div>
+
+<div class="panel">
+    <h2>3. Received Messages Log</h2>
     <pre id="log"></pre>
 </div>
 
@@ -44,56 +52,86 @@
 
     function log(message) {
         const logElement = document.getElementById('log');
-        logElement.innerText += message + '\n';
-        logElement.scrollTop = logElement.scrollHeight; // Auto-scroll
+        logElement.innerText += `[${new Date().toLocaleTimeString()}] ${message}\n`;
+        logElement.scrollTop = logElement.scrollHeight;
+    }
+
+    function updateParticipantList(roomState) {
+        const listElement = document.getElementById('participantList');
+        const roomNameTitle = document.getElementById('roomNameTitle');
+        listElement.innerHTML = ''; // 목록 비우기
+
+        roomNameTitle.innerText = `${roomState.roomName} (Participants)`;
+
+        // 1. 방장 추가
+        const ownerItem = document.createElement('li');
+        ownerItem.className = 'owner';
+        ownerItem.innerText = `👑 ${roomState.owner.userName} (${roomState.owner.userId})`;
+        listElement.appendChild(ownerItem);
+
+        // 2. 나머지 참여자 추가
+        roomState.participants.forEach(p => {
+            const participantItem = document.createElement('li');
+            participantItem.innerText = `👤 ${p.userName} (${p.userId})`;
+            listElement.appendChild(participantItem);
+        });
     }
 
     function connect() {
         const roomId = document.getElementById('roomId').value;
-        const sessionId = document.getElementById('sessionId').value; // ✨ sessionId 가져오기
+        const sessionId = document.getElementById('sessionId').value;
+        const myUserId = document.getElementById('myUserId').value;
         const jwtToken = document.getElementById('jwtToken').value;
-        if (!roomId || !jwtToken || !sessionId) { // ✨ sessionId 유효성 검사 추가
-            alert('Room ID, Session ID, JWT Token을 모두 입력하세요.');
+
+        if (!roomId || !jwtToken || !sessionId || !myUserId) {
+            alert('모든 필드를 입력하세요.');
             return;
         }
 
         const headers = { 'Authorization': 'Bearer ' + jwtToken };
         const socket = new SockJS('http://localhost:8080/ws-collab');
         stompClient = Stomp.over(socket);
+        stompClient.debug = null; // STOMP 라이브러리 자체 로그 끄기
 
         stompClient.connect(headers, function (frame) {
-            log('Connected: ' + frame);
+            log('✅ Connected to WebSocket Server.');
+            document.querySelector('[onclick="connect()"]').disabled = true;
+            document.querySelector('[onclick="disconnect()"]').disabled = false;
+            document.getElementById('editor').disabled = false;
 
-            // ✨ 1. 코드 업데이트 구독 (세션별 주소로 변경)
+            // --- 1. 방 상태(참여자 목록) 업데이트 구독 ---
+            const systemTopic = `/topic/room/${roomId}/system`;
+            stompClient.subscribe(systemTopic, function (message) {
+                const roomState = JSON.parse(message.body);
+                log(`🔄 Received Room State Update. Owner: ${roomState.owner.userName}, Participants: ${roomState.participants.length}`);
+                updateParticipantList(roomState);
+            });
+            log(`👂 Subscribed to: ${systemTopic}`);
+
+            // --- 2. 코드 수정 내용 구독 ---
             const codeTopic = `/topic/room/${roomId}/session/${sessionId}/code`;
             stompClient.subscribe(codeTopic, function (message) {
                 const received = JSON.parse(message.body);
-                log(`Code updated in session ${sessionId} by ${received.senderName || received.senderId}.`);
-                document.getElementById('editor').value = received.content;
+                // 내가 보낸 메시지는 다시 받아서 에디터를 덮어쓰지 않도록 처리
+                if (received.senderId !== myUserId) {
+                    log(`💻 Code updated by ${received.senderName || received.senderId}.`);
+                    document.getElementById('editor').value = received.content;
+                }
             });
-            log('Subscribed to: ' + codeTopic);
-
-            // 2. 권한 변경 구독 (방 전체 주소 유지)
-            const permissionTopic = `/topic/room/${roomId}/permission`;
-            stompClient.subscribe(permissionTopic, function (message) {
-                const received = JSON.parse(message.body);
-                log(`Permission granted to ${received.targetUserName || received.targetUserId} by ${received.senderName || received.senderId}`);
-            });
-            log('Subscribed to: ' + permissionTopic);
+            log(`👂 Subscribed to: ${codeTopic}`);
 
         }, function(error) {
-            log('STOMP error: ' + error);
+            log('❌ STOMP connection error: ' + error);
         });
     }
 
     function sendCodeUpdate() {
         if (stompClient && stompClient.connected) {
             const roomId = document.getElementById('roomId').value;
-            const sessionId = document.getElementById('sessionId').value; // ✨ sessionId 가져오기
+            const sessionId = document.getElementById('sessionId').value;
             const myUserId = document.getElementById('myUserId').value;
             const content = document.getElementById('editor').value;
 
-            // ✨ 메시지 전송 주소 변경
             const destination = `/app/room/${roomId}/session/${sessionId}/code-update`;
             stompClient.send(destination, {}, JSON.stringify({
                 'senderId': myUserId,
@@ -102,42 +140,18 @@
         }
     }
 
-    function grantPermission() {
-        if (stompClient && stompClient.connected) {
-            const roomId = document.getElementById('roomId').value;
-            const myUserId = document.getElementById('myUserId').value;
-            const targetUserId = document.getElementById('targetUserId').value;
-
-            // ✨ 권한 변경은 방 전체에 대한 것이므로 주소 유지
-            const destination = `/app/room/${roomId}/grant-permission`;
-            stompClient.send(destination, {}, JSON.stringify({
-                'senderId': myUserId,
-                'targetUserId': targetUserId
-            }));
-        }
-    }
-
-    function revokePermission() {
-        if (stompClient && stompClient.connected) {
-            const roomId = document.getElementById('roomId').value;
-            const myUserId = document.getElementById('myUserId').value;
-            const targetUserId = document.getElementById('revokeTargetUserId').value;
-
-            // 새로 추가한 revoke-permission 엔드포인트로 메시지 전송
-            const destination = `/app/room/${roomId}/revoke-permission`;
-            stompClient.send(destination, {}, JSON.stringify({
-                'senderId': myUserId,
-                'targetUserId': targetUserId
-            }));
-        }
-    }
-
     function disconnect() {
         if (stompClient !== null) {
-            stompClient.disconnect();
+            stompClient.disconnect(() => {
+                log('🔌 Disconnected from WebSocket Server.');
+                document.querySelector('[onclick="connect()"]').disabled = false;
+                document.querySelector('[onclick="disconnect()"]').disabled = true;
+                document.getElementById('editor').disabled = true;
+                document.getElementById('participantList').innerHTML = '';
+                document.getElementById('roomNameTitle').innerText = 'Participants';
+            });
         }
-        log("Disconnected");
     }
 </script>
 </body>
-</html>ㄴ
+</html>


### PR DESCRIPTION
## 📋 PR 개요
기존에 구현된 세션 관리 서비스 로직을 `RoomController`에 REST API 엔드포인트로 연동하고, 사용자 입장/퇴장 시 전체 참여자 목록을 실시간으로 동기화하는 기능을 추가합니다.

---

## 💻 주요 변경 사항
- **REST API 구현 (Controller 연동)**:
  - 직전 커밋에서 구현된 서비스 로직들을 `RoomController`에 REST API 엔드포인트로 연결했습니다.
  - **참가자 강퇴**: `DELETE /api/collab/rooms/{roomId}/participants/{targetUserId}`
  - **세션 상태 변경**: `PATCH /api/collab/sessions/{sessionId}/status`
  - **세션 권한 부여/회수**: `POST` 및 `DELETE /api/collab/sessions/{sessionId}/permissions/{targetUserId}`
  - 모든 신규 API에 Swagger 문서화를 적용하여 프론트엔드와의 연동 편의성을 높였습니다.

- **실시간 참여자 목록 동기화**:
  - `WebSocketEventListener`의 로직을 전면 수정하여, 사용자가 입장하거나 퇴장할 때마다 방의 최신 전체 참여자 목록(`RoomStateUpdate` DTO)을 `/topic/room/{roomId}/system` 채널로 브로드캐스팅하도록 변경했습니다.
  - 기존의 "OOO님이 입장했습니다"와 같은 단순 텍스트 알림 방식 대신, 프론트엔드가 UI 상태를 직접 동기화할 수 있는 구조화된 데이터를 제공합니다.
  - 이를 위해 `RoomStateUpdate`, `ParticipantInfo` DTO를 신규 생성했습니다.

---

## 🔗 관련 이슈
- Closes #36