### PR TITLE
feat: 협업 방 참여 기능 및 실시간 목록 동기화 추가(#39)

### DIFF
--- a/src/main/java/com/dmu/debug_visual/collab/domain/repository/RoomParticipantRepository.java
+++ b/src/main/java/com/dmu/debug_visual/collab/domain/repository/RoomParticipantRepository.java
@@ -2,10 +2,12 @@ package com.dmu.debug_visual.collab.domain.repository;
 
 import com.dmu.debug_visual.collab.domain.entity.Room;
 import com.dmu.debug_visual.collab.domain.entity.RoomParticipant;
+import com.dmu.debug_visual.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface RoomParticipantRepository extends JpaRepository<RoomParticipant, Long> {
     Optional<RoomParticipant> findByRoomAndUser_UserId(Room room, String userId);
+    boolean existsByRoomAndUser(Room room, User user);
 }

--- a/src/main/java/com/dmu/debug_visual/collab/service/RoomService.java
+++ b/src/main/java/com/dmu/debug_visual/collab/service/RoomService.java
@@ -220,4 +220,32 @@ public class RoomService {
         }
         return session;
     }
+
+    /**
+     * 사용자를 특정 방의 참여자로 등록합니다.
+     * @param roomId 참여할 방의 ID
+     * @param userId 참여할 사용자의 ID
+     */
+    @Transactional
+    public void joinRoom(String roomId, String userId) {
+        Room room = roomRepository.findByRoomId(roomId)
+                .orElseThrow(() -> new EntityNotFoundException("Room not found: " + roomId));
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found: " + userId));
+
+        // 💡 이미 참여자인지 확인하여 중복 등록을 방지합니다.
+        boolean isAlreadyParticipant = roomParticipantRepository.existsByRoomAndUser(room, user);
+        if (isAlreadyParticipant) {
+            // 이미 참여자이면 아무것도 하지 않고 성공으로 간주
+            return;
+        }
+
+        // 새로운 참여자로 등록 (기본 권한은 READ_ONLY)
+        RoomParticipant newParticipant = RoomParticipant.builder()
+                .room(room)
+                .user(user)
+                .permission(RoomParticipant.Permission.READ_ONLY)
+                .build();
+        roomParticipantRepository.save(newParticipant);
+    }
 }


### PR DESCRIPTION
## 📋 PR 개요
사용자가 협업 방에 참여자로 등록하는 API를 구현하고, 이를 통해 입장/퇴장 시 전체 참여자 목록이 모든 클라이언트에게 실시간으로 정확하게 동기화되도록 합니다.

---

## 💻 주요 변경 사항
- **서비스 로직 구현**:
  - `RoomService`에 새로운 참여자를 `RoomParticipant` 테이블에 저장하는 `joinRoom` 메소드를 추가했습니다.
  - 이미 참여자인 경우 중복으로 등록되지 않도록 방지하는 로직을 포함했습니다.

- **REST API 구현**:
  - `RoomController`에 사용자가 특정 방에 참여 요청을 보낼 수 있는 `POST /api/collab/rooms/{roomId}/participants` 엔드포인트를 추가했습니다.
  - 해당 API에 대한 Swagger 문서화를 완료하여 프론트엔드와의 연동 편의성을 높였습니다.

- **실시간 동기화 로직 완성**:
  - `WebSocketEventListener`의 기존 `broadcastRoomState` 로직은 이제 `joinRoom` API를 통해 DB에 등록된 정확한 참여자 목록을 기반으로 동작합니다.
  - 이로써, 새로운 사용자가 참여 API를 호출한 후 WebSocket에 연결하면, 모든 클라이언트가 최신 참여자 목록을 수신하여 UI를 동기화할 수 있게 되었습니다.

---

## 🔗 관련 이슈
- Closes #39