### PR TITLE
feat: 파일 삭제 및 내용 조회 기능 추가(#43)

### DIFF
--- a/src/main/java/com/dmu/debug_visual/file_upload/FileController.java
+++ b/src/main/java/com/dmu/debug_visual/file_upload/FileController.java
@@ -1,5 +1,6 @@
 package com.dmu.debug_visual.file_upload;
 
+import com.dmu.debug_visual.file_upload.dto.FileContentResponse;
 import com.dmu.debug_visual.file_upload.dto.FileResponseDTO;
 import com.dmu.debug_visual.file_upload.dto.UserFileDTO;
 import com.dmu.debug_visual.file_upload.service.FileService;
@@ -21,55 +22,87 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.List;
 
-@Tag(name = "파일 관리 API", description = "S3 파일 생성, 수정(덮어쓰기) 및 사용자별 파일 목록 조회를 제공합니다.")
+@Tag(name = "파일 관리 API", description = "S3 파일 생성, 수정, 조회 및 삭제 기능을 제공합니다.")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/file") // 경로를 단수로 통일
+@RequestMapping("/api/file")
 public class FileController {
 
     private final FileService fileService;
+
+    // =================================================================================
+    // == 1. 파일 생성 및 수정 (Create & Update)
+    // =================================================================================
 
     @Operation(summary = "파일 저장 또는 수정 (덮어쓰기)",
             description = "form-data로 파일을 업로드합니다. `fileUUID` 파라미터 유무에 따라 동작이 달라집니다.\n\n" +
                     "- **`fileUUID`가 없으면**: 신규 파일로 저장하고 새로운 `fileUUID`를 발급합니다.\n" +
                     "- **`fileUUID`가 있으면**: 해당 `fileUUID`를 가진 기존 파일을 덮어씁니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "요청 성공 (생성 또는 수정 완료)",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = FileResponseDTO.class))),
-            @ApiResponse(responseCode = "401", description = "인증 실패 (JWT 토큰 누락 또는 유효하지 않음)", content = @Content),
-            @ApiResponse(responseCode = "403", description = "권한 없음 (타인의 파일 수정을 시도)", content = @Content),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 `fileUUID`로 수정 요청", content = @Content)
+            @ApiResponse(responseCode = "200", description = "요청 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = FileResponseDTO.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 `fileUUID`로 수정 요청")
     })
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<FileResponseDTO> uploadOrUpdateFile(
-            @Parameter(description = "업로드할 파일")
-            @RequestParam("file") MultipartFile file,
-
-            @Parameter(description = "수정할 파일의 고유 ID. 신규 업로드 시에는 생략합니다.")
-            @RequestParam(value = "fileUUID", required = false) String fileUUID,
-
+            @Parameter(description = "업로드할 파일") @RequestParam("file") MultipartFile file,
+            @Parameter(description = "수정할 파일의 고유 ID. 신규 업로드 시에는 생략합니다.") @RequestParam(value = "fileUUID", required = false) String fileUUID,
             @AuthenticationPrincipal CustomUserDetails userDetails) throws IOException {
 
-        // CustomUserDetails에서 사용자 ID (Long 타입)를 가져오는 메소드가 있다고 가정합니다.
-        // 예: userDetails.getId()
         String currentUserId = userDetails.getUsername();
-
         FileResponseDTO fileResponse = fileService.saveOrUpdateFile(fileUUID, file, currentUserId);
         return ResponseEntity.ok(fileResponse);
     }
 
+    // =================================================================================
+    // == 2. 파일 조회 (Read)
+    // =================================================================================
+
     @Operation(summary = "내 파일 목록 조회", description = "현재 로그인한 사용자가 생성한 모든 파일의 목록을 조회합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserFileDTO.class))),
-            @ApiResponse(responseCode = "401", description = "인증 실패 (JWT 토큰 누락 또는 유효하지 않음)", content = @Content)
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserFileDTO.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @GetMapping("/my")
-    public ResponseEntity<List<UserFileDTO>> getMyFiles(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-
+    public ResponseEntity<List<UserFileDTO>> getMyFiles(@AuthenticationPrincipal CustomUserDetails userDetails) {
         String currentUserId = userDetails.getUsername();
         List<UserFileDTO> myFiles = fileService.getUserFiles(currentUserId);
         return ResponseEntity.ok(myFiles);
     }
+
+    @Operation(summary = "파일 내용 조회", description = "특정 파일의 내용을 조회합니다. 본인의 파일만 조회할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = FileContentResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "파일을 찾을 수 없음")
+    })
+    @GetMapping("/{fileUUID}/content")
+    public ResponseEntity<FileContentResponse> getFileContent(
+            @Parameter(description = "내용을 조회할 파일의 고유 ID") @PathVariable String fileUUID,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        FileContentResponse response = fileService.getFileContent(fileUUID, userDetails.getUsername());
+        return ResponseEntity.ok(response);
+    }
+
+    // =================================================================================
+    // == 3. 파일 삭제 (Delete)
+    // =================================================================================
+
+    @Operation(summary = "파일 삭제", description = "특정 파일을 S3와 DB에서 모두 삭제합니다. 본인의 파일만 삭제할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "삭제 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "파일을 찾을 수 없음")
+    })
+    @DeleteMapping("/{fileUUID}")
+    public ResponseEntity<Void> deleteFile(
+            @Parameter(description = "삭제할 파일의 고유 ID") @PathVariable String fileUUID,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        fileService.deleteFile(fileUUID, userDetails.getUsername());
+        return ResponseEntity.ok().build();
+    }
 }
+

--- a/src/main/java/com/dmu/debug_visual/file_upload/dto/FileContentResponse.java
+++ b/src/main/java/com/dmu/debug_visual/file_upload/dto/FileContentResponse.java
@@ -1,0 +1,11 @@
+package com.dmu.debug_visual.file_upload.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FileContentResponse {
+    private String originalFileName;
+    private String content;
+}

--- a/src/main/java/com/dmu/debug_visual/file_upload/service/S3Uploader.java
+++ b/src/main/java/com/dmu/debug_visual/file_upload/service/S3Uploader.java
@@ -4,12 +4,21 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
+/**
+ * AWS S3와의 직접적인 통신(업로드, 조회, 삭제)을 담당하는 서비스 클래스.
+ * 이 클래스는 비즈니스 로직을 포함하지 않고, 순수하게 S3 작업만 처리합니다.
+ */
 @Service
 @RequiredArgsConstructor
 public class S3Uploader {
@@ -19,23 +28,63 @@ public class S3Uploader {
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
 
+    // =================================================================================
+    // == 1. 파일 생성 및 수정 (Create & Update)
+    // =================================================================================
+
     /**
      * S3에 파일을 업로드(또는 덮어쓰기)하고 URL을 반환합니다.
-     * 이제 이 메소드는 파일 경로를 직접 만들지 않고, 파라미터로 받습니다.
+     * @param file 업로드할 파일
+     * @param s3FilePath S3에 저장될 경로 (key)
+     * @return 업로드된 파일의 S3 URL
      */
     public String upload(MultipartFile file, String s3FilePath) throws IOException {
-        // 1. S3에 업로드할 요청 객체 생성 (전달받은 s3FilePath를 key로 사용)
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucket)
-                .key(s3FilePath) // UUID로 새로 만드는 대신, 전달받은 경로를 그대로 사용
+                .key(s3FilePath)
                 .contentType(file.getContentType())
                 .contentLength(file.getSize())
                 .build();
 
-        // 2. 파일의 InputStream을 RequestBody로 만들어 S3에 업로드
         s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
 
-        // 3. 업로드된 파일의 URL 반환
         return s3Client.utilities().getUrl(builder -> builder.bucket(bucket).key(s3FilePath)).toString();
     }
+
+    // =================================================================================
+    // == 2. 파일 조회 (Read)
+    // =================================================================================
+
+    /**
+     * S3에서 특정 파일의 내용을 문자열로 읽어옵니다.
+     * @param s3FilePath 조회할 파일의 S3 경로 (key)
+     * @return 파일 내용 (UTF-8 문자열)
+     */
+    public String getFileContent(String s3FilePath) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3FilePath)
+                .build();
+
+        ResponseBytes<GetObjectResponse> objectBytes = s3Client.getObjectAsBytes(getObjectRequest);
+        return objectBytes.asString(StandardCharsets.UTF_8);
+    }
+
+    // =================================================================================
+    // == 3. 파일 삭제 (Delete)
+    // =================================================================================
+
+    /**
+     * S3에서 특정 파일을 삭제합니다.
+     * @param s3FilePath 삭제할 파일의 S3 경로 (key)
+     */
+    public void deleteFile(String s3FilePath) {
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3FilePath)
+                .build();
+
+        s3Client.deleteObject(deleteObjectRequest);
+    }
 }
+


### PR DESCRIPTION
## 📋 PR 개요
사용자가 자신이 업로드한 파일의 내용을 조회하고, 파일을 영구적으로 삭제할 수 있는 기능을 구현합니다.

---

## 💻 주요 변경 사항
- **S3 통신 계층 (`S3Uploader`)**:
  - `getFileContent` 메소드를 추가하여, S3에서 특정 파일의 내용을 UTF-8 문자열로 읽어오는 기능을 구현했습니다.
  - `deleteFile` 메소드를 추가하여, S3에서 특정 객체를 삭제하는 기능을 구현했습니다.

- **서비스 로직 (`FileService`)**:
  - `getFileContent` 비즈니스 로직을 구현하여, 파일 소유주를 확인한 후 `S3Uploader`를 통해 파일 내용을 반환하도록 했습니다.
  - `deleteFile` 비즈니스 로직을 구현하여, 파일 소유주를 확인한 후 `S3Uploader`를 통해 S3 파일을 먼저 삭제하고, 그 다음에 DB의 메타데이터를 삭제하도록 구현했습니다.
  - `findAndVerifyOwner` private 헬퍼 메소드를 추가하여, 여러 메소드에서 사용되는 권한 검사 로직을 중앙화하고 코드 중복을 제거했습니다.

- **API 엔드포인트 (`FileController`)**:
  - `GET /api/file/{fileUUID}/content` 엔드포인트를 추가하여 파일 내용을 조회할 수 있도록 했습니다.
  - `DELETE /api/file/{fileUUID}` 엔드포인트를 추가하여 파일을 삭제할 수 있도록 했습니다.
  - 모든 신규 API에 Swagger 문서화를 적용하여 명세를 명확히 했습니다.

---

## 🔗 관련 이슈
- Closes #43 