### PR TITLE
feat: 알림 클릭 시 게시물 이동 기능 추가(#45)

### DIFF
--- a/src/main/java/com/dmu/debug_visual/community/dto/NotificationResponse.java
+++ b/src/main/java/com/dmu/debug_visual/community/dto/NotificationResponse.java
@@ -1,0 +1,35 @@
+package com.dmu.debug_visual.community.dto;
+
+import com.dmu.debug_visual.community.entity.Notification;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 알림 정보를 프론트엔드에 전달하기 위한 DTO
+ */
+@Getter
+@Builder
+public class NotificationResponse {
+    private Long notificationId;
+    private String message;
+    private boolean isRead;
+    private Notification.NotificationType notificationType;
+    private LocalDateTime createdAt;
+    private Long postId;
+
+    /**
+     * Notification 엔티티를 NotificationResponse DTO로 변환하는 정적 팩토리 메소드
+     */
+    public static NotificationResponse fromEntity(Notification notification) {
+        return NotificationResponse.builder()
+                .notificationId(notification.getId())
+                .message(notification.getMessage())
+                .isRead(notification.isRead())
+                .notificationType(notification.getNotificationType())
+                .createdAt(notification.getCreatedAt())
+                .postId(notification.getPostId())
+                .build();
+    }
+}

--- a/src/main/java/com/dmu/debug_visual/community/entity/Notification.java
+++ b/src/main/java/com/dmu/debug_visual/community/entity/Notification.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Setter
+@Setter // 참고: 엔티티에 @Setter를 사용하는 것은 객체의 상태를 쉽게 변경할 수 있어 위험할 수 있습니다. 가능하면 markAsRead() 같은 명확한 메소드를 사용하는 것이 좋습니다.
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -17,18 +17,40 @@ public class Notification {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "receiver_id") // 외래키 컬럼 이름을 명시적으로 지정해주는 것이 좋습니다.
     private User receiver;
 
+    @Column(nullable = false)
     private String message;
 
     @Builder.Default
+    @Column(nullable = false)
     private boolean isRead = false;
 
     private LocalDateTime createdAt;
 
+    // ✨ [추가] 알림 타입을 구분하기 위한 필드 (예: 댓글, 좋아요)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType notificationType;
+
+    public enum NotificationType {
+        COMMENT, // 댓글
+        LIKE    // 좋아요
+    }
+
+    // ✨ [추가] 알림을 클릭했을 때 이동할 게시물의 ID
+    @Column
+    private Long postId;
+
     @PrePersist
     public void prePersist() {
         this.createdAt = LocalDateTime.now();
+    }
+
+    // 읽음 처리 편의 메소드
+    public void markAsRead() {
+        this.isRead = true;
     }
 }

--- a/src/main/java/com/dmu/debug_visual/community/service/NotificationService.java
+++ b/src/main/java/com/dmu/debug_visual/community/service/NotificationService.java
@@ -5,6 +5,7 @@ import com.dmu.debug_visual.community.repository.NotificationRepository;
 import com.dmu.debug_visual.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -14,12 +15,27 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
 
+    /**
+     * 일반 알림을 생성합니다. (게시물 ID가 없는 경우)
+     * @param receiver 알림을 받을 사용자
+     * @param message  알림 내용
+     */
+    @Transactional
     public void notify(User receiver, String message) {
-        Notification notification = Notification.builder()
-                .receiver(receiver)
-                .message(message)
-                .build();
-        notificationRepository.save(notification);
+        // postId가 없는 경우, null로 저장합니다.
+        // 좋아요 기능 등에서 이 메소드를 호출할 수 있습니다.
+        createAndSaveNotification(receiver, message, null, Notification.NotificationType.LIKE); // 기본 타입을 LIKE 등으로 설정
+    }
+
+    /**
+     * 게시물과 관련된 알림을 생성합니다. (댓글 등)
+     * @param receiver 알림을 받을 사용자
+     * @param message  알림 내용
+     * @param postId   관련된 게시물의 ID
+     */
+    @Transactional
+    public void notify(User receiver, String message, Long postId) {
+        createAndSaveNotification(receiver, message, postId, Notification.NotificationType.COMMENT);
     }
 
     public List<Notification> getUserNotifications(User user) {
@@ -33,6 +49,19 @@ public class NotificationService {
             throw new RuntimeException("권한 없음");
         }
         notification.setRead(true);
+        notificationRepository.save(notification);
+    }
+
+    /**
+     * Notification 엔티티를 생성하고 저장하는 private 헬퍼 메소드
+     */
+    private void createAndSaveNotification(User receiver, String message, Long postId, Notification.NotificationType type) {
+        Notification notification = Notification.builder()
+                .receiver(receiver)
+                .message(message)
+                .notificationType(type)
+                .postId(postId) // postId가 null이 아니면 저장, null이면 null로 저장
+                .build();
         notificationRepository.save(notification);
     }
 }


### PR DESCRIPTION
## 📋 PR 개요
알림 데이터에 관련 게시물 ID(`postId`)를 포함하여, 사용자가 알림을 통해 해당 게시물로 직접 이동할 수 있는 기반을 마련합니다.

---

## 💻 주요 변경 사항
- **데이터베이스 모델링**:
  - `Notification` 엔티티에 `postId`와 알림 유형을 구분하기 위한 `notificationType` 필드를 추가했습니다.
  - 기존 엔티티 구조와 호환되도록 필드(`receiver`, `message`)는 유지하면서 기능을 확장했습니다.

- **서비스 로직 수정**:
  - `CommentService`에서 댓글 또는 대댓글 생성 시, `NotificationService`를 호출할 때 해당 게시물의 `postId`를 함께 전달하도록 수정했습니다.
  - `NotificationService`에 `postId`를 파라미터로 받는 `notify` 메소드를 오버로딩하여, 알림 생성 시 `postId`가 함께 저장되도록 구현했습니다.

- **DTO 수정**:
  - `NotificationResponse` DTO에 `postId` 필드를 추가하고, `fromEntity` 정적 메소드에 관련 매핑 로직을 추가했습니다.
  - 이를 통해, 알림 조회 API가 프론트엔드에 `postId`를 전달하여 바로가기 링크를 구현할 수 있도록 했습니다.

---

## 🔗 관련 이슈
- Closes #45 