### PR TITLE
fix: 댓글 작성 403 및 알림 생성 DB 오류 수정

### DIFF
--- a/src/main/java/com/dmu/debug_visual/community/entity/Notification.java
+++ b/src/main/java/com/dmu/debug_visual/community/entity/Notification.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Setter // 참고: 엔티티에 @Setter를 사용하는 것은 객체의 상태를 쉽게 변경할 수 있어 위험할 수 있습니다. 가능하면 markAsRead() 같은 명확한 메소드를 사용하는 것이 좋습니다.
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -18,7 +18,7 @@ public class Notification {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "receiver_id") // 외래키 컬럼 이름을 명시적으로 지정해주는 것이 좋습니다.
+    @JoinColumn(name = "receiver_user_num")
     private User receiver;
 
     @Column(nullable = false)
@@ -30,17 +30,15 @@ public class Notification {
 
     private LocalDateTime createdAt;
 
-    // ✨ [추가] 알림 타입을 구분하기 위한 필드 (예: 댓글, 좋아요)
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private NotificationType notificationType;
 
     public enum NotificationType {
-        COMMENT, // 댓글
-        LIKE    // 좋아요
+        COMMENT,
+        LIKE
     }
 
-    // ✨ [추가] 알림을 클릭했을 때 이동할 게시물의 ID
     @Column
     private Long postId;
 
@@ -49,7 +47,6 @@ public class Notification {
         this.createdAt = LocalDateTime.now();
     }
 
-    // 읽음 처리 편의 메소드
     public void markAsRead() {
         this.isRead = true;
     }

--- a/src/main/java/com/dmu/debug_visual/community/repository/CommentRepository.java
+++ b/src/main/java/com/dmu/debug_visual/community/repository/CommentRepository.java
@@ -3,9 +3,18 @@ package com.dmu.debug_visual.community.repository;
 import com.dmu.debug_visual.community.entity.Comment;
 import com.dmu.debug_visual.community.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPostAndParentIsNull(Post post);
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.writer WHERE c.id = :commentId")
+    Optional<Comment> findByIdWithWriter(@Param("commentId") Long commentId);
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.writer WHERE c.post = :post AND c.parent IS NULL")
+    List<Comment> findByPostAndParentIsNullWithWriter(@Param("post") Post post);
 }

--- a/src/main/java/com/dmu/debug_visual/community/repository/PostRepository.java
+++ b/src/main/java/com/dmu/debug_visual/community/repository/PostRepository.java
@@ -2,6 +2,16 @@ package com.dmu.debug_visual.community.repository;
 
 import com.dmu.debug_visual.community.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+    /**
+     * Post를 조회할 때 writer(User) 객체를 함께 Fetch Join 합니다.
+     * N+1 문제를 방지하고 LazyInitializationException을 해결합니다.
+     */
+    @Query("SELECT p FROM Post p JOIN FETCH p.writer WHERE p.id = :postId")
+    Optional<Post> findByIdWithWriter(@Param("postId") Long postId);
 }

--- a/src/main/java/com/dmu/debug_visual/community/service/CommentService.java
+++ b/src/main/java/com/dmu/debug_visual/community/service/CommentService.java
@@ -19,11 +19,13 @@ public class CommentService {
     private final PostRepository postRepository;
     private final NotificationService notificationService;
 
-    Comment parent = null;
+    // ★ [수정] 싱글톤 서비스에서 상태를 가지는 필드는 스레드 충돌을 일으키므로 삭제
+    // Comment parent = null;
 
     @Transactional
     public Long createComment(CommentRequestDTO dto, User user) {
-        Post post = postRepository.findById(dto.getPostId())
+        // ★ [수정] postRepository.findById() -> findByIdWithWriter()로 변경
+        Post post = postRepository.findByIdWithWriter(dto.getPostId())
                 .orElseThrow(() -> new RuntimeException("게시글 없음"));
 
         Comment.CommentBuilder builder = Comment.builder()
@@ -31,10 +33,12 @@ public class CommentService {
                 .writer(user)
                 .content(dto.getContent());
 
+        // 메서드 내의 지역 변수로 사용하는 것이 올바른 방법입니다.
         Comment parent = null;
 
         if (dto.getParentId() != null && dto.getParentId() != 0) {
-            parent = commentRepository.findById(dto.getParentId())
+            // ★ [수정] commentRepository.findById() -> findByIdWithWriter()로 변경
+            parent = commentRepository.findByIdWithWriter(dto.getParentId())
                     .orElseThrow(() -> new RuntimeException("상위 댓글 없음"));
 
             if (parent.getParent() != null) {
@@ -44,16 +48,14 @@ public class CommentService {
             builder.parent(parent);
 
             if (!user.getUserNum().equals(parent.getWriter().getUserNum())) {
-                // 대댓글 알림 시 postId 추가
                 notificationService.notify(
                         parent.getWriter(),
                         user.getName() + "님이 댓글에 답글을 남겼습니다.",
-                        post.getId() // 게시물 ID 전달
+                        post.getId()
                 );
             }
         }
 
-        // 게시글 작성자에게 알림 (작성자 본인이 아닌 경우)
         if (!user.getUserNum().equals(post.getWriter().getUserNum())) {
             notificationService.notify(
                     post.getWriter(),
@@ -70,7 +72,8 @@ public class CommentService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new RuntimeException("게시글 없음"));
 
-        List<Comment> rootComments = commentRepository.findByPostAndParentIsNull(post);
+        // ★ [수정] N+1 문제를 일부 해결하기 위해 writer를 함께 조회하는 메서드 사용
+        List<Comment> rootComments = commentRepository.findByPostAndParentIsNullWithWriter(post);
 
         return rootComments.stream()
                 .map(this::mapToDTO)
@@ -83,6 +86,7 @@ public class CommentService {
                 .writer(comment.getWriter().getName())
                 .content(comment.isDeleted() ? "삭제된 댓글입니다." : comment.getContent())
                 .createdAt(comment.getCreatedAt())
+                // 참고: 이 부분(children)은 여전히 N+1 문제가 발생할 수 있습니다.
                 .replies(comment.getChildren().stream()
                         .map(this::mapToDTO)
                         .collect(Collectors.toList()))
@@ -93,15 +97,11 @@ public class CommentService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new RuntimeException("댓글 없음"));
 
-        // 본인 확인
         if (!comment.getWriter().getUserNum().equals(user.getUserNum())) {
             throw new RuntimeException("댓글 삭제 권한 없음");
         }
 
-        // 논리 삭제
         comment.setDeleted(true);
         commentRepository.save(comment);
     }
-
-
 }

--- a/src/main/java/com/dmu/debug_visual/community/service/PostService.java
+++ b/src/main/java/com/dmu/debug_visual/community/service/PostService.java
@@ -9,6 +9,7 @@ import com.dmu.debug_visual.community.repository.PostRepository;
 import com.dmu.debug_visual.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional; // ★ Transactional 추가
 
 import java.util.List;
 import java.util.Optional;
@@ -22,6 +23,7 @@ public class PostService {
     private final LikeRepository likeRepository;
     private final NotificationService notificationService;
 
+    @Transactional // ★ 추가
     public Long createPost(PostRequestDTO dto, User user) {
         Post post = Post.builder()
                 .title(dto.getTitle())
@@ -30,9 +32,9 @@ public class PostService {
                 .writer(user)
                 .build();
 
-        if (!post.getWriter().getUserNum().equals(user.getUserNum())) {
-            notificationService.notify(post.getWriter(), user.getName() + "님이 게시글을 좋아합니다.");
-        }
+        // ★ [수정] createPost 시 알림 로직 삭제
+        // (이 로직은 본인(writer)과 user가 같으므로 항상 false가 되어 실행되지 않음)
+        // if (!post.getWriter().getUserNum().equals(user.getUserNum())) { ... }
 
         return postRepository.save(post).getId();
     }
@@ -43,9 +45,8 @@ public class PostService {
                         .id(post.getId())
                         .title(post.getTitle())
                         .content(post.getContent())
-                        .writer(post.getWriter().getName()) // 수정: username → name
+                        .writer(post.getWriter().getName())
                         .tags(post.getTags())
-//                        .imageUrl(post.getImageUrl())
                         .createdAt(post.getCreatedAt())
                         .likeCount(likeRepository.countByPost(post))
                         .build())
@@ -53,34 +54,36 @@ public class PostService {
     }
 
     public PostResponseDTO getPost(Long id) {
-        Post post = postRepository.findById(id)
+        // ★ [수정] N+1 문제 해결을 위해 findByIdWithWriter 사용 권장
+        // (PostRepository에 findByIdWithWriter가 있다고 가정)
+        Post post = postRepository.findByIdWithWriter(id)
                 .orElseThrow(() -> new RuntimeException("Post not found"));
         return PostResponseDTO.builder()
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
-                .writer(post.getWriter().getName()) // 수정
+                .writer(post.getWriter().getName())
                 .tags(post.getTags())
                 .createdAt(post.getCreatedAt())
                 .likeCount(likeRepository.countByPost(post))
                 .build();
     }
 
-
-
+    @Transactional // ★ 추가
     public void deletePost(Long id, User user) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Post not found"));
 
-        if (!post.getWriter().getUserNum().equals(user.getUserNum())) { // 수정
+        if (!post.getWriter().getUserNum().equals(user.getUserNum())) {
             throw new RuntimeException("권한 없음");
         }
         postRepository.delete(post);
     }
 
-
+    @Transactional // ★ 추가
     public boolean toggleLike(Long postId, User user) {
-        Post post = postRepository.findById(postId)
+        // ★ [수정] N+1 문제 해결을 위해 findByIdWithWriter 사용
+        Post post = postRepository.findByIdWithWriter(postId)
                 .orElseThrow(() -> new RuntimeException("게시글 없음"));
 
         Optional<Like> existing = likeRepository.findByPostAndUser(post, user);
@@ -94,6 +97,16 @@ public class PostService {
                     .user(user)
                     .build();
             likeRepository.save(like);
+
+            // ★ [수정] 좋아요 시 알림 로직 추가 (본인이 본인 글을 좋아하지 않는 경우)
+            if (!post.getWriter().getUserNum().equals(user.getUserNum())) {
+                notificationService.notify(
+                        post.getWriter(),
+                        user.getName() + "님이 회원님의 게시글을 좋아합니다.",
+                        post.getId() // postId도 함께 전달
+                );
+            }
+
             return true; // 등록됨
         }
     }
@@ -104,5 +117,4 @@ public class PostService {
 
         return likeRepository.countByPost(post);
     }
-
 }

--- a/src/main/java/com/dmu/debug_visual/config/SecurityConfig.java
+++ b/src/main/java/com/dmu/debug_visual/config/SecurityConfig.java
@@ -38,7 +38,6 @@ public class SecurityConfig {
 
     /**
      * "dev" 프로파일 (개발 환경)을 위한 보안 설정
-     * ADMIN 권한 체크를 제외하여 USER 권한으로도 ADMIN API 테스트가 가능합니다.
      */
     @Bean
     @Profile("dev")
@@ -55,15 +54,21 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/users/login", "/api/users/signup").permitAll()
                         .requestMatchers("/api/code/**").permitAll()
+                        // ★ (유지) GET 요청은 누구나 접근 가능
                         .requestMatchers(HttpMethod.GET, "/api/posts/**", "/api/comments/**").permitAll()
 
-                        // 2. USER 권한이 필요한 경로
-                        .requestMatchers("/api/posts/**").hasRole("USER")
-                        .requestMatchers("/api/notifications/**").hasRole("USER")
-                        .requestMatchers("/api/report/**").hasRole("USER")
-                        .requestMatchers("/api/comments/**").hasRole("USER")
-                        .requestMatchers("/api/files/**").hasRole("USER")
-                        .requestMatchers("/api/collab").hasRole("USER")
+                        // 2. USER 또는 ADMIN 권한이 필요한 경로
+                        // ★ (수정) POST, PUT, DELETE 등 GET 외의 메서드는 USER 또는 ADMIN 권한 필요
+                        .requestMatchers(HttpMethod.POST, "/api/posts/**", "/api/comments/**", "/api/notifications/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/posts/**", "/api/comments/**", "/api/notifications/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/posts/**", "/api/comments/**", "/api/notifications/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers(HttpMethod.PATCH, "/api/posts/**", "/api/comments/**", "/api/notifications/**").hasAnyRole("USER", "ADMIN")
+
+                        // ★ (수정) GET을 제외한 나머지 /api/notifications/** 경로는 여기서 처리됩니다.
+                        .requestMatchers("/api/notifications/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers("/api/report/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers("/api/files/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers("/api/collab").hasAnyRole("USER", "ADMIN")
 
                         // 3. 나머지 모든 요청은 인증된 사용자만 접근 가능 (ADMIN 경로 포함)
                         .anyRequest().authenticated()
@@ -75,7 +80,6 @@ public class SecurityConfig {
 
     /**
      * "prod", "default" 등 운영 환경을 위한 보안 설정
-     * ADMIN 경로는 ADMIN 권한이 있는 사용자만 접근 가능합니다.
      */
     @Bean
     @Profile("!dev")
@@ -92,18 +96,24 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/users/login", "/api/users/signup").permitAll()
                         .requestMatchers("/api/code/**").permitAll()
+                        // ★ (유지) GET 요청은 누구나 접근 가능
                         .requestMatchers(HttpMethod.GET, "/api/posts/**", "/api/comments/**").permitAll()
 
-                        // 2. ADMIN 권한이 필요한 경로
+                        // 2. ADMIN 권한이 필요한 경로 (먼저 정의)
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
 
-                        // 3. USER 권한이 필요한 경로
-                        .requestMatchers("/api/posts/**").hasRole("USER")
-                        .requestMatchers("/api/notifications/**").hasRole("USER")
-                        .requestMatchers("/api/report/**").hasRole("USER")
-                        .requestMatchers("/api/comments/**").hasRole("USER")
-                        .requestMatchers("/api/files/**").hasRole("USER")
-                        .requestMatchers("/api/collab").hasRole("USER")
+                        // 3. USER 또는 ADMIN 권한이 필요한 경로
+                        // ★ (수정) POST, PUT, DELETE 등 GET 외의 메서드는 USER 또는 ADMIN 권한 필요
+                        .requestMatchers(HttpMethod.POST, "/api/posts/**", "/api/comments/**", "/api/notifications/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/posts/**", "/api/comments/**", "/api/notifications/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/posts/**", "/api/comments/**", "/api/notifications/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers(HttpMethod.PATCH, "/api/posts/**", "/api/comments/**", "/api/notifications/**").hasAnyRole("USER", "ADMIN") // (PATCH도 명시)
+
+                        // ★ (수정) GET을 제외한 나머지 /api/notifications/** 경로는 여기서 처리됩니다.
+                        .requestMatchers("/api/notifications/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers("/api/report/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers("/api/files/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers("/api/collab").hasAnyRole("USER", "ADMIN")
 
 
                         // 4. 나머지 모든 요청은 인증된 사용자만 접근 가능
@@ -132,7 +142,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOriginPatterns(List.of("*"));
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
 


### PR DESCRIPTION
## 📋 PR 개요
`POST /api/comments` API 호출 시 발생하던 `403 Forbidden` 시큐리티 오류와, 이후 연쇄적으로 발생한 `SQLException` 데이터베이스 오류를 해결합니다.

---

## 💻 주요 변경 사항
- **`SecurityConfig` 수정:**
  - `GET` 요청(`permitAll`)과 `POST/PUT/PATCH/DELETE` 요청(`hasAnyRole`)의 규칙이 충돌하지 않도록 `HttpMethod`별로 명확하게 분리했습니다.
  - `CorsConfigurationSource`에 `PATCH` 메서드를 허용 목록에 추가했습니다.

- **`Notification.java` (엔티티) 수정:**
  - `receiver` 필드의 `@JoinColumn`을 `receiver_id`에서 실제 DB 컬럼명인 `receiver_user_num`으로 수정하여 DB `INSERT` 오류를 해결했습니다.

- **`CommentService` 수정:**
  - `postRepository`와 `commentRepository`가 `findById` 대신 `findByIdWithWriter` (Fetch Join)를 사용하도록 수정하여, Lazy Loading으로 인한 `user_num` `null` 참조 오류를 해결했습니다.
  - 스레드 충돌 위험이 있는 클래스 레벨 필드(`Comment parent`)를 삭제하고 지역 변수로 변경했습니다.

- **`PostRepository` / `CommentRepository` 수정:**
  - `writer`를 `JOIN FETCH`하는 `findByIdWithWriter` 및 `findByPostAndParentIsNullWithWriter` 커스텀 쿼리 메서드를 추가했습니다.

- **`PostService` 수정:** (부가적인 수정 사항)
  - `toggleLike` 시 알림이 전송되도록 로직을 추가하고, `createPost`의 불필요한 알림 로직을 제거했습니다.
  - 데이터 변경 메서드에 `@Transactional`을 추가하고 Fetch Join을 적용했습니다.

---

## 🔗 관련 이슈
- Closes #50