### PR TITLE
fix: 알림 조회 API Jackson 직렬화 오류 수정 (#52)

### DIFF
--- a/src/main/java/com/dmu/debug_visual/community/controller/NotificationController.java
+++ b/src/main/java/com/dmu/debug_visual/community/controller/NotificationController.java
@@ -1,37 +1,82 @@
 package com.dmu.debug_visual.community.controller;
 
-import com.dmu.debug_visual.community.entity.Notification;
+import com.dmu.debug_visual.community.dto.NotificationResponse;
 import com.dmu.debug_visual.community.service.NotificationService;
 import com.dmu.debug_visual.security.CustomUserDetails;
 import com.dmu.debug_visual.user.User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity; // ResponseEntity 사용
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * 사용자 알림 관련 API 요청을 처리하는 컨트롤러 클래스.
+ */
 @RestController
 @RequestMapping("/api/notifications")
 @RequiredArgsConstructor
-@Tag(name = "알림 API", description = "사용자에게 전달되는 알림 API")
+@Tag(name = "알림 API", description = "사용자 알림 조회 및 읽음 처리 API") // 태그 이름에 이모지 추가
+@SecurityRequirement(name = "bearerAuth") // 모든 API에 JWT 인증 필요 명시
 public class NotificationController {
 
     private final NotificationService notificationService;
 
+    /**
+     * 현재 로그인한 사용자의 모든 알림 목록을 조회합니다.
+     *
+     * @param userDetails 현재 로그인한 사용자의 정보 (JWT 토큰에서 추출)
+     * @return 알림 DTO 리스트 (최신순 정렬)
+     */
     @GetMapping
-    @Operation(summary = "내 알림 목록 조회")
-    public List<Notification> getMyNotifications(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    @Operation(summary = "내 알림 목록 조회", description = "현재 로그인된 사용자의 모든 알림을 최신순으로 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = NotificationResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content)
+    })
+    public ResponseEntity<List<NotificationResponse>> getMyNotifications(
+            @Parameter(hidden = true) // Swagger UI에서 파라미터 숨김 처리
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
         User user = userDetails.getUser();
-        return notificationService.getUserNotifications(user);
+        List<NotificationResponse> notifications = notificationService.getUserNotifications(user);
+        return ResponseEntity.ok(notifications); // ResponseEntity로 감싸서 반환
     }
 
+    /**
+     * 특정 알림을 읽음 상태로 변경합니다.
+     *
+     * @param id          읽음 처리할 알림의 ID
+     * @param userDetails 현재 로그인한 사용자의 정보 (JWT 토큰에서 추출)
+     */
     @PutMapping("/{id}/read")
-    @Operation(summary = "알림 읽음 처리")
-    public void markAsRead(@PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    @Operation(summary = "알림 읽음 처리", description = "특정 알림 ID를 받아 해당 알림을 읽음 상태로 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "읽음 처리 성공", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음 (본인 알림 아님)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "해당 ID의 알림 없음", content = @Content)
+    })
+    public ResponseEntity<Void> markAsRead( // 반환 타입 void 대신 ResponseEntity<Void> 사용
+                                            @Parameter(description = "읽음 처리할 알림 ID", required = true, example = "1")
+                                            @PathVariable Long id,
+                                            @Parameter(hidden = true) // Swagger UI에서 파라미터 숨김 처리
+                                            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
         User user = userDetails.getUser();
         notificationService.markAsRead(id, user);
+        return ResponseEntity.ok().build(); // 성공 시 200 OK만 반환
     }
-
 }

--- a/src/main/java/com/dmu/debug_visual/community/service/CommentService.java
+++ b/src/main/java/com/dmu/debug_visual/community/service/CommentService.java
@@ -1,8 +1,11 @@
 package com.dmu.debug_visual.community.service;
 
-import com.dmu.debug_visual.community.dto.*;
-import com.dmu.debug_visual.community.entity.*;
-import com.dmu.debug_visual.community.repository.*;
+import com.dmu.debug_visual.community.dto.CommentRequestDTO;
+import com.dmu.debug_visual.community.dto.CommentResponseDTO;
+import com.dmu.debug_visual.community.entity.Comment;
+import com.dmu.debug_visual.community.entity.Post;
+import com.dmu.debug_visual.community.repository.CommentRepository;
+import com.dmu.debug_visual.community.repository.PostRepository;
 import com.dmu.debug_visual.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,6 +14,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * 게시글 댓글 관련 비즈니스 로직을 처리하는 서비스 클래스.
+ */
 @Service
 @RequiredArgsConstructor
 public class CommentService {
@@ -19,89 +25,122 @@ public class CommentService {
     private final PostRepository postRepository;
     private final NotificationService notificationService;
 
-    // ★ [수정] 싱글톤 서비스에서 상태를 가지는 필드는 스레드 충돌을 일으키므로 삭제
-    // Comment parent = null;
-
+    /**
+     * 새로운 댓글 또는 대댓글을 생성하고 저장합니다.
+     * 댓글 생성 시 게시글 작성자에게, 대댓글 생성 시 부모 댓글 작성자에게 알림을 전송합니다.
+     *
+     * @param dto  댓글 생성 요청 정보 (postId, content, parentId)
+     * @param user 댓글 작성자
+     * @return 생성된 댓글의 ID
+     */
     @Transactional
     public Long createComment(CommentRequestDTO dto, User user) {
-        // ★ [수정] postRepository.findById() -> findByIdWithWriter()로 변경
+        // Fetch Join을 사용하여 Post 조회 시 writer 정보도 함께 로드
         Post post = postRepository.findByIdWithWriter(dto.getPostId())
-                .orElseThrow(() -> new RuntimeException("게시글 없음"));
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다. ID: " + dto.getPostId()));
 
         Comment.CommentBuilder builder = Comment.builder()
                 .post(post)
                 .writer(user)
                 .content(dto.getContent());
 
-        // 메서드 내의 지역 변수로 사용하는 것이 올바른 방법입니다.
-        Comment parent = null;
-
+        // 대댓글 처리
         if (dto.getParentId() != null && dto.getParentId() != 0) {
-            // ★ [수정] commentRepository.findById() -> findByIdWithWriter()로 변경
-            parent = commentRepository.findByIdWithWriter(dto.getParentId())
-                    .orElseThrow(() -> new RuntimeException("상위 댓글 없음"));
+            // Fetch Join을 사용하여 부모 댓글 조회 시 writer 정보도 함께 로드
+            Comment parent = commentRepository.findByIdWithWriter(dto.getParentId())
+                    .orElseThrow(() -> new RuntimeException("상위 댓글을 찾을 수 없습니다. ID: " + dto.getParentId()));
 
+            // 대댓글의 대댓글은 허용하지 않음
             if (parent.getParent() != null) {
                 throw new IllegalArgumentException("대댓글에는 답글을 달 수 없습니다.");
             }
 
             builder.parent(parent);
 
+            // 대댓글 작성 시, 부모 댓글 작성자와 현재 작성자가 다르면 알림 전송
             if (!user.getUserNum().equals(parent.getWriter().getUserNum())) {
-                notificationService.notify(
-                        parent.getWriter(),
-                        user.getName() + "님이 댓글에 답글을 남겼습니다.",
-                        post.getId()
-                );
+                String message = user.getName() + "님이 회원님의 댓글에 답글을 남겼습니다.";
+                notificationService.notify(parent.getWriter(), message, post.getId());
             }
         }
 
+        // 댓글 저장
+        Comment savedComment = commentRepository.save(builder.build());
+
+        // 댓글 작성 시, 게시글 작성자와 현재 작성자가 다르면 알림 전송
+        // (대댓글인 경우에도 게시글 작성자에게 알림 전송)
         if (!user.getUserNum().equals(post.getWriter().getUserNum())) {
-            notificationService.notify(
-                    post.getWriter(),
-                    user.getName() + "님이 게시글에 댓글을 남겼습니다.",
-                    post.getId()
-            );
+            String message = user.getName() + "님이 회원님의 게시글에 댓글을 남겼습니다.";
+            notificationService.notify(post.getWriter(), message, post.getId());
         }
 
-        return commentRepository.save(builder.build()).getId();
+        return savedComment.getId();
     }
 
-
+    /**
+     * 특정 게시글의 댓글 목록을 조회합니다 (대댓글 포함).
+     *
+     * @param postId 댓글 목록을 조회할 게시글 ID
+     * @return 댓글 DTO 리스트 (계층 구조)
+     */
+    @Transactional(readOnly = true) // 읽기 전용 트랜잭션 명시
     public List<CommentResponseDTO> getComments(Long postId) {
+        // 게시글 존재 여부 확인 (writer 정보는 필요 없으므로 기본 findById 사용)
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new RuntimeException("게시글 없음"));
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다. ID: " + postId));
 
-        // ★ [수정] N+1 문제를 일부 해결하기 위해 writer를 함께 조회하는 메서드 사용
+        // 최상위 댓글 목록 조회 (writer 정보 포함)
         List<Comment> rootComments = commentRepository.findByPostAndParentIsNullWithWriter(post);
 
         return rootComments.stream()
-                .map(this::mapToDTO)
+                .map(this::mapToDTO) // DTO 변환 메소드 재귀 호출
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 특정 댓글을 논리적으로 삭제 처리합니다.
+     *
+     * @param commentId 삭제할 댓글 ID
+     * @param user      현재 로그인한 사용자 (권한 확인용)
+     */
+    @Transactional // 데이터 변경이 있으므로 트랜잭션 명시
+    public void deleteComment(Long commentId, User user) {
+        // 댓글 조회 (writer 정보는 권한 확인에 필요 없으므로 기본 findById 사용)
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다. ID: " + commentId));
+
+        // 댓글 작성자와 현재 사용자가 일치하는지 확인
+        if (!comment.getWriter().getUserNum().equals(user.getUserNum())) {
+            throw new RuntimeException("댓글 삭제 권한이 없습니다. (댓글 ID: " + commentId + ")");
+        }
+
+        // 논리 삭제 처리
+        comment.setDeleted(true);
+        // @Transactional 환경에서는 명시적인 save 호출 없이 더티 체킹으로 업데이트 가능
+        // commentRepository.save(comment);
+    }
+
+    // --- Private Helper Methods ---
+
+    /**
+     * Comment 엔티티를 CommentResponseDTO로 변환합니다 (재귀 호출 지원).
+     *
+     * @param comment 변환할 Comment 엔티티
+     * @return 변환된 CommentResponseDTO
+     */
     private CommentResponseDTO mapToDTO(Comment comment) {
+        // 재귀 호출 시 children의 writer 로딩으로 N+1 발생 가능성 있음
+        // 성능 최적화가 필요하다면 EntityGraph 또는 별도 조회 쿼리 고려
         return CommentResponseDTO.builder()
                 .id(comment.getId())
+                // writer 필드는 getComments에서 Fetch Join 되었으므로 getName() 호출 가능
                 .writer(comment.getWriter().getName())
                 .content(comment.isDeleted() ? "삭제된 댓글입니다." : comment.getContent())
                 .createdAt(comment.getCreatedAt())
-                // 참고: 이 부분(children)은 여전히 N+1 문제가 발생할 수 있습니다.
                 .replies(comment.getChildren().stream()
+                        .filter(child -> !child.isDeleted()) // 논리 삭제된 대댓글은 제외 (선택사항)
                         .map(this::mapToDTO)
                         .collect(Collectors.toList()))
                 .build();
-    }
-
-    public void deleteComment(Long commentId, User user) {
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new RuntimeException("댓글 없음"));
-
-        if (!comment.getWriter().getUserNum().equals(user.getUserNum())) {
-            throw new RuntimeException("댓글 삭제 권한 없음");
-        }
-
-        comment.setDeleted(true);
-        commentRepository.save(comment);
     }
 }

--- a/src/main/java/com/dmu/debug_visual/community/service/NotificationService.java
+++ b/src/main/java/com/dmu/debug_visual/community/service/NotificationService.java
@@ -1,5 +1,6 @@
 package com.dmu.debug_visual.community.service;
 
+import com.dmu.debug_visual.community.dto.NotificationResponse;
 import com.dmu.debug_visual.community.entity.Notification;
 import com.dmu.debug_visual.community.repository.NotificationRepository;
 import com.dmu.debug_visual.user.User;
@@ -8,27 +9,33 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+/**
+ * 사용자 알림 관련 비즈니스 로직을 처리하는 서비스 클래스.
+ */
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
 
+    // --- Public Methods ---
+
     /**
-     * 일반 알림을 생성합니다. (게시물 ID가 없는 경우)
+     * 일반 알림(게시물 ID 없음, 예: 좋아요)을 생성하고 저장합니다.
+     *
      * @param receiver 알림을 받을 사용자
      * @param message  알림 내용
      */
     @Transactional
     public void notify(User receiver, String message) {
-        // postId가 없는 경우, null로 저장합니다.
-        // 좋아요 기능 등에서 이 메소드를 호출할 수 있습니다.
-        createAndSaveNotification(receiver, message, null, Notification.NotificationType.LIKE); // 기본 타입을 LIKE 등으로 설정
+        createAndSaveNotification(receiver, message, null, Notification.NotificationType.LIKE);
     }
 
     /**
-     * 게시물과 관련된 알림을 생성합니다. (댓글 등)
+     * 게시물 관련 알림(예: 댓글)을 생성하고 저장합니다.
+     *
      * @param receiver 알림을 받을 사용자
      * @param message  알림 내용
      * @param postId   관련된 게시물의 ID
@@ -38,29 +45,57 @@ public class NotificationService {
         createAndSaveNotification(receiver, message, postId, Notification.NotificationType.COMMENT);
     }
 
-    public List<Notification> getUserNotifications(User user) {
-        return notificationRepository.findByReceiverOrderByCreatedAtDesc(user);
-    }
-
-    public void markAsRead(Long notificationId, User user) {
-        Notification notification = notificationRepository.findById(notificationId)
-                .orElseThrow(() -> new RuntimeException("알림 없음"));
-        if (!notification.getReceiver().getUserNum().equals(user.getUserNum())) {
-            throw new RuntimeException("권한 없음");
-        }
-        notification.setRead(true);
-        notificationRepository.save(notification);
+    /**
+     * 특정 사용자의 모든 알림 목록을 DTO 리스트 형태로 조회합니다.
+     *
+     * @param user 알림 목록을 조회할 사용자
+     * @return 알림 DTO 리스트 (최신순 정렬)
+     */
+    public List<NotificationResponse> getUserNotifications(User user) {
+        List<Notification> notifications = notificationRepository.findByReceiverOrderByCreatedAtDesc(user);
+        return notifications.stream()
+                .map(NotificationResponse::fromEntity)
+                .collect(Collectors.toList());
     }
 
     /**
-     * Notification 엔티티를 생성하고 저장하는 private 헬퍼 메소드
+     * 특정 알림을 읽음 상태로 변경합니다.
+     *
+     * @param notificationId 읽음 처리할 알림의 ID
+     * @param user           현재 로그인한 사용자 (권한 확인용)
+     */
+    @Transactional
+    public void markAsRead(Long notificationId, User user) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new RuntimeException("알림 없음 ID: " + notificationId));
+
+        // 알림 수신자와 현재 사용자가 일치하는지 확인
+        if (!notification.getReceiver().getUserNum().equals(user.getUserNum())) {
+            throw new RuntimeException("알림 읽기 권한 없음 (알림 ID: " + notificationId + ")");
+        }
+
+        notification.markAsRead();
+        // @Transactional 환경에서는 명시적인 save 호출 없이 더티 체킹으로 업데이트 가능
+        // notificationRepository.save(notification);
+    }
+
+    // --- Private Helper Methods ---
+
+    /**
+     * Notification 엔티티를 생성하고 데이터베이스에 저장합니다.
+     *
+     * @param receiver 알림을 받을 사용자
+     * @param message  알림 내용
+     * @param postId   관련된 게시물의 ID (nullable)
+     * @param type     알림 유형 (COMMENT, LIKE 등)
      */
     private void createAndSaveNotification(User receiver, String message, Long postId, Notification.NotificationType type) {
         Notification notification = Notification.builder()
                 .receiver(receiver)
                 .message(message)
                 .notificationType(type)
-                .postId(postId) // postId가 null이 아니면 저장, null이면 null로 저장
+                .postId(postId)
+                // isRead는 @Builder.Default로 false가 기본값이므로 생략 가능
                 .build();
         notificationRepository.save(notification);
     }


### PR DESCRIPTION
## 📋 PR 개요
`GET /api/notifications` API 호출 시 하이버네이트 지연 로딩 프록시 객체로 인해 발생하던 Jackson JSON 직렬화 오류 (`InvalidDefinitionException`)를 해결합니다. 엔티티 대신 DTO를 사용하도록 수정하고 관련 코드를 정리합니다.

---

## 💻 주요 변경 사항
- **`NotificationResponse` DTO 추가**:
  - 알림 목록 API 응답에 사용될 `NotificationResponse` DTO 클래스를 생성했습니다.
  - 엔티티를 DTO로 변환하는 `fromEntity` 정적 팩토리 메소드를 포함합니다.

- **`NotificationService` 수정**:
  - `getUserNotifications` 메소드의 반환 타입을 `List<Notification>`에서 `List<NotificationResponse>`로 변경하고, 내부에서 DTO 변환 로직을 수행하도록 수정했습니다.
  - `markAsRead` 메소드에 `@Transactional`을 추가하고 코드를 정리했습니다.
  - 전체적인 코드 가독성 향상을 위해 주석 추가 및 포맷팅을 진행했습니다.

- **`NotificationController` 수정**:
  - `getMyNotifications` 메소드의 반환 타입을 `ResponseEntity<List<NotificationResponse>>`로 변경하여 DTO를 반환하도록 수정했습니다.
  - `markAsRead` 메소드의 반환 타입을 `ResponseEntity<Void>`로 변경했습니다.
  - Swagger 어노테이션 (`@ApiResponses`, `@Parameter`, `@SecurityRequirement` 등)을 추가/개선하여 API 문서를 명확하게 했습니다.
  - 전체적인 코드 가독성 향상을 위해 주석 추가 및 포맷팅을 진행했습니다.

---

## 🔗 관련 이슈
- Closes #52 